### PR TITLE
Remove redundant Linux dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ Since building nRF Connect also involves building *pc-ble-driver-js*, please ref
 To build the project on Ubuntu Linux, the following packages need to be installed:
 
 * libudev-dev
-* libx11-dev
-* libxkbfile-dev
 
 ### Windows
 


### PR DESCRIPTION
The libx11-dev and libxkbfile-dev packages were required when we had the atom-keymap npm dependency. This was removed a while ago, so we no longer need these packages when installing on Linux.