### PR TITLE
Add main menu dropdown in the top-left corner

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ nRF Connect respects the `main` field in the plugin's package.json, so the entry
         <code>decorateLogHeader</code><br />
         <code>decorateLogHeaderButton</code><br />
         <code>decorateLogViewer</code><br />
+        <code>decorateMainMenu</code><br />
         <code>decorateMainView</code><br />
         <code>decorateNavBar</code><br />
         <code>decorateNavMenu</code><br />
@@ -183,6 +184,7 @@ nRF Connect respects the `main` field in the plugin's package.json, so the entry
         <code>mapFirmwareDialogDispatch</code><br />
         <code>mapLogHeaderDispatch</code><br />
         <code>mapLogViewerDispatch</code><br />
+        <code>mapMainMenuDispatch</code><br />
         <code>mapMainViewDispatch</code><br />
         <code>mapNavMenuDispatch</code><br />
         <code>mapSerialPortSelectorDispatch</code><br />
@@ -209,6 +211,7 @@ nRF Connect respects the `main` field in the plugin's package.json, so the entry
         <code>mapFirmwareDialogState</code><br />
         <code>mapLogHeaderState</code><br />
         <code>mapLogViewerState</code><br />
+        <code>mapMainMenuState</code><br />
         <code>mapMainViewState</code><br />
         <code>mapNavMenuState</code><br />
         <code>mapSerialPortSelectorState</code><br />

--- a/index.js
+++ b/index.js
@@ -43,13 +43,10 @@ const packageJson = require('./package.json');
 
 const app = electron.app;
 const Menu = electron.Menu;
+const ipcMain = electron.ipcMain;
 
 global.homeDir = app.getPath('home');
 global.userDataDir = app.getPath('userData');
-
-app.on('window-all-closed', () => {
-    app.quit();
-});
 
 function initBrowserWindow() {
     const applicationMenu = Menu.buildFromTemplate(createMenu(app));
@@ -64,4 +61,19 @@ function initBrowserWindow() {
 
 app.on('ready', () => {
     initBrowserWindow();
+});
+
+app.on('window-all-closed', () => {
+    app.quit();
+});
+
+ipcMain.on('open-plugin-manager', () => {
+    // TODO: Implement when multi-window support is available.
+    /*
+    browser.createWindow({
+        title: `nRF Connect v${packageJson.version}`,
+        url: `file://${__dirname}/lib/windows/loader`,
+        splashScreen: false,
+    });
+    */
 });

--- a/lib/windows/plugin/actions/mainMenuActions.js
+++ b/lib/windows/plugin/actions/mainMenuActions.js
@@ -1,0 +1,52 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { ipcRenderer } from 'electron';
+
+export const OPEN_PLUGIN_MANAGER = 'MAIN_MENU_OPEN_PLUGIN_MANAGER';
+
+function openPluginManagerAction() {
+    return {
+        type: OPEN_PLUGIN_MANAGER,
+    };
+}
+
+export function openPluginManager() {
+    return dispatch => {
+        dispatch(openPluginManagerAction());
+        ipcRenderer.send('open-plugin-manager');
+    };
+}

--- a/lib/windows/plugin/components/MainMenu.jsx
+++ b/lib/windows/plugin/components/MainMenu.jsx
@@ -1,0 +1,100 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React, { PropTypes } from 'react';
+import Immutable from 'immutable';
+import { Dropdown, MenuItem, Glyphicon } from 'react-bootstrap';
+import DropdownToggle from 'react-bootstrap/lib/DropdownToggle';
+import DropdownMenu from 'react-bootstrap/lib/DropdownMenu';
+
+const renderItems = (menuItems, bindHotkey) => (
+    menuItems.map(item => {
+        if (item.hotkey) {
+            bindHotkey(item.hotkey.toLowerCase(), item.onClick);
+        }
+        return (
+            <MenuItem
+                key={item.id}
+                onClick={item.onClick}
+                divider={item.isDivider}
+                title={item.hotkey ? `${item.text} (${item.hotkey})` : item.text}
+            >
+                {item.text}
+            </MenuItem>
+        );
+    })
+);
+
+const MainMenu = ({
+    menuItems,
+    bindHotkey,
+    glyphiconName,
+    cssClass,
+    dropdownCssClass,
+    dropdownMenuCssClass,
+}) => (
+    <div className={cssClass}>
+        <Dropdown id="main-menu">
+            <DropdownToggle className={dropdownCssClass} noCaret>
+                <Glyphicon glyph={glyphiconName} />
+            </DropdownToggle>
+            <DropdownMenu id="main-menu-list" className={dropdownMenuCssClass}>
+                { renderItems(menuItems, bindHotkey) }
+            </DropdownMenu>
+        </Dropdown>
+    </div>
+);
+
+MainMenu.propTypes = {
+    menuItems: PropTypes.oneOfType([
+        PropTypes.instanceOf(Array),
+        PropTypes.instanceOf(Immutable.Iterable),
+    ]).isRequired,
+    bindHotkey: PropTypes.func.isRequired,
+    glyphiconName: PropTypes.string,
+    cssClass: PropTypes.string,
+    dropdownCssClass: PropTypes.string,
+    dropdownMenuCssClass: PropTypes.string,
+};
+
+MainMenu.defaultProps = {
+    glyphiconName: 'menu-hamburger',
+    cssClass: 'nav-section bl padded-row',
+    dropdownCssClass: 'main-menu btn-primary btn-nordic',
+    dropdownMenuCssClass: 'dropdown-menu-nordic',
+};
+
+export default MainMenu;

--- a/lib/windows/plugin/components/NavBar.jsx
+++ b/lib/windows/plugin/components/NavBar.jsx
@@ -38,6 +38,7 @@ import React, { PropTypes } from 'react';
 import logo from '../../../../resources/nordiclogo_neg.png';
 import SerialPortSelectorContainer from '../containers/SerialPortSelectorContainer';
 import NavMenuContainer from '../containers/NavMenuContainer';
+import MainMenuContainer from '../containers/MainMenuContainer';
 
 const NavBar = ({
     logoSrc,
@@ -49,6 +50,7 @@ const NavBar = ({
     logoCssClass,
 }) => (
     <div className={cssClass}>
+        <MainMenuContainer />
         <div className={navSectionCssClass}>
             <SerialPortSelectorContainer />
         </div>

--- a/lib/windows/plugin/components/SerialPortSelector.jsx
+++ b/lib/windows/plugin/components/SerialPortSelector.jsx
@@ -35,7 +35,9 @@
  */
 
 import React, { PropTypes } from 'react';
-import { DropdownButton } from 'react-bootstrap';
+import { Dropdown } from 'react-bootstrap';
+import DropdownToggle from 'react-bootstrap/lib/DropdownToggle';
+import DropdownMenu from 'react-bootstrap/lib/DropdownMenu';
 import { Iterable } from 'immutable';
 import SerialPortSelectorItem from './SerialPortSelectorItem';
 import { decorate } from '../../../util/plugins';
@@ -103,6 +105,7 @@ class SerialPortSelector extends React.Component {
             hotkeyExpand,
             cssClass,
             dropdownCssClass,
+            dropdownMenuCssClass,
         } = this.props;
 
         const selectorText = selectedPort || 'Select serial port';
@@ -111,16 +114,19 @@ class SerialPortSelector extends React.Component {
         return (
             <span title={`Select serial port (${hotkeyExpand})`}>
                 <div className={cssClass}>
-                    <DropdownButton
-                        id="navbar-dropdown"
-                        className={dropdownCssClass}
-                        title={selectorText}
-                        open={isExpanded}
-                        onToggle={toggleExpanded}
-                    >
-                        { this.renderSerialPortItems() }
-                        { this.renderCloseItem() }
-                    </DropdownButton>
+                    <Dropdown id="serial-port-selector" open={isExpanded} onToggle={toggleExpanded}>
+                        <DropdownToggle
+                            className={dropdownCssClass}
+                            title={selectorText}
+                        />
+                        <DropdownMenu
+                            id="serial-port-selector-list"
+                            className={dropdownMenuCssClass}
+                        >
+                            { this.renderSerialPortItems() }
+                            { this.renderCloseItem() }
+                        </DropdownMenu>
+                    </Dropdown>
                     {
                         showPortIndicator ? <div className={indicatorCssClass} /> : <div />
                     }
@@ -147,6 +153,7 @@ SerialPortSelector.propTypes = {
     hotkeyExpand: PropTypes.string,
     cssClass: PropTypes.string,
     dropdownCssClass: PropTypes.string,
+    dropdownMenuCssClass: PropTypes.string,
     menuItemCssClass: PropTypes.string,
 };
 
@@ -158,7 +165,8 @@ SerialPortSelector.defaultProps = {
     portIndicatorStatus: 'off',
     hotkeyExpand: 'Alt+P',
     cssClass: 'padded-row',
-    dropdownCssClass: 'btn-primary btn-nordic',
+    dropdownCssClass: 'serial-port-selector btn-primary btn-nordic',
+    dropdownMenuCssClass: 'dropdown-menu-nordic',
     menuItemCssClass: 'btn-primary',
 };
 

--- a/lib/windows/plugin/components/__tests__/MainMenu-test.jsx
+++ b/lib/windows/plugin/components/__tests__/MainMenu-test.jsx
@@ -1,0 +1,98 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* eslint-disable import/first */
+
+// Do not decorate components
+jest.mock('../../../../util/plugins', () => ({
+    decorate: component => component,
+}));
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import Immutable from 'immutable';
+import MainMenu from '../MainMenu';
+
+const menuItems = Immutable.List([
+    {
+        id: 1,
+        text: 'First item',
+    }, {
+        id: 2,
+        isDivider: true,
+    }, {
+        id: 3,
+        text: 'Last item',
+    },
+]);
+
+describe('MainMenu', () => {
+    it('should render menu with no items', () => {
+        expect(renderer.create(
+            <MainMenu
+                menuItems={[]}
+                bindHotkey={() => {}}
+            />,
+        )).toMatchSnapshot();
+    });
+
+    it('should render menu with two items separated by divider', () => {
+        expect(renderer.create(
+            <MainMenu
+                menuItems={menuItems}
+                bindHotkey={() => {}}
+            />,
+        )).toMatchSnapshot();
+    });
+
+    it('should invoke onClick when item has been clicked', () => {
+        const onClick = jest.fn();
+        const wrapper = mount(
+            <MainMenu
+                menuItems={[{
+                    id: 1,
+                    text: 'Foo',
+                    onClick,
+                }]}
+                bindHotkey={() => {}}
+            />,
+        );
+        wrapper.find('a[title="Foo"]').first().simulate('click');
+
+        expect(onClick).toHaveBeenCalled();
+    });
+});

--- a/lib/windows/plugin/components/__tests__/SerialPortSelector-test.jsx
+++ b/lib/windows/plugin/components/__tests__/SerialPortSelector-test.jsx
@@ -38,9 +38,11 @@
 
 // Do not render react-bootstrap components in tests
 jest.mock('react-bootstrap', () => ({
-    DropdownButton: 'DropdownButton',
+    Dropdown: 'Dropdown',
     MenuItem: 'MenuItem',
 }));
+jest.mock('react-bootstrap/lib/DropdownToggle', () => 'DropdownToggle');
+jest.mock('react-bootstrap/lib/DropdownMenu', () => 'DropdownMenu');
 
 // Do not decorate components
 jest.mock('../../../../util/plugins', () => ({

--- a/lib/windows/plugin/components/__tests__/__snapshots__/MainMenu-test.jsx.snap
+++ b/lib/windows/plugin/components/__tests__/__snapshots__/MainMenu-test.jsx.snap
@@ -1,0 +1,88 @@
+exports[`MainMenu should render menu with no items 1`] = `
+<div
+  className="nav-section bl padded-row">
+  <div
+    className="dropdown btn-group">
+    <button
+      aria-expanded={false}
+      aria-haspopup={true}
+      className="main-menu btn-primary btn-nordic dropdown-toggle btn btn-default"
+      disabled={false}
+      id="main-menu"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      type="button">
+      <span
+        className="glyphicon glyphicon-menu-hamburger" />
+    </button>
+    <ul
+      aria-labelledby="main-menu"
+      className="dropdown-menu-nordic dropdown-menu"
+      id="main-menu-list"
+      role="menu" />
+  </div>
+</div>
+`;
+
+exports[`MainMenu should render menu with two items separated by divider 1`] = `
+<div
+  className="nav-section bl padded-row">
+  <div
+    className="dropdown btn-group">
+    <button
+      aria-expanded={false}
+      aria-haspopup={true}
+      className="main-menu btn-primary btn-nordic dropdown-toggle btn btn-default"
+      disabled={false}
+      id="main-menu"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      type="button">
+      <span
+        className="glyphicon glyphicon-menu-hamburger" />
+    </button>
+    <ul
+      aria-labelledby="main-menu"
+      className="dropdown-menu-nordic dropdown-menu"
+      id="main-menu-list"
+      role="menu">
+      <li
+        className=""
+        role="presentation"
+        style={undefined}>
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+          title="First item">
+          First item
+        </a>
+      </li>
+      <li
+        className="divider"
+        onKeyDown={[Function]}
+        role="separator"
+        style={undefined}
+        title={undefined} />
+      <li
+        className=""
+        role="presentation"
+        style={undefined}>
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+          title="Last item">
+          Last item
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/lib/windows/plugin/components/__tests__/__snapshots__/SerialPortSelector-test.jsx.snap
+++ b/lib/windows/plugin/components/__tests__/__snapshots__/SerialPortSelector-test.jsx.snap
@@ -3,12 +3,17 @@ exports[`SerialPortSelector should render empty list while loading 1`] = `
   title="Select serial port (Alt+P)">
   <div
     className="padded-row">
-    <DropdownButton
-      className="btn-primary btn-nordic"
-      id="navbar-dropdown"
+    <Dropdown
+      id="serial-port-selector"
       onToggle={[Function]}
-      open={true}
-      title="Select serial port" />
+      open={true}>
+      <DropdownToggle
+        className="serial-port-selector btn-primary btn-nordic"
+        title="Select serial port" />
+      <DropdownMenu
+        className="dropdown-menu-nordic"
+        id="serial-port-selector-list" />
+    </Dropdown>
     <div
       className="indicator off" />
   </div>
@@ -20,12 +25,17 @@ exports[`SerialPortSelector should render empty port list, expanded 1`] = `
   title="Select serial port (Alt+P)">
   <div
     className="padded-row">
-    <DropdownButton
-      className="btn-primary btn-nordic"
-      id="navbar-dropdown"
+    <Dropdown
+      id="serial-port-selector"
       onToggle={[Function]}
-      open={true}
-      title="Select serial port" />
+      open={true}>
+      <DropdownToggle
+        className="serial-port-selector btn-primary btn-nordic"
+        title="Select serial port" />
+      <DropdownMenu
+        className="dropdown-menu-nordic"
+        id="serial-port-selector-list" />
+    </Dropdown>
     <div
       className="indicator off" />
   </div>
@@ -37,12 +47,17 @@ exports[`SerialPortSelector should render empty port list, not expanded 1`] = `
   title="Select serial port (Alt+P)">
   <div
     className="padded-row">
-    <DropdownButton
-      className="btn-primary btn-nordic"
-      id="navbar-dropdown"
+    <Dropdown
+      id="serial-port-selector"
       onToggle={[Function]}
-      open={false}
-      title="Select serial port" />
+      open={false}>
+      <DropdownToggle
+        className="serial-port-selector btn-primary btn-nordic"
+        title="Select serial port" />
+      <DropdownMenu
+        className="dropdown-menu-nordic"
+        id="serial-port-selector-list" />
+    </Dropdown>
     <div
       className="indicator off" />
   </div>
@@ -54,45 +69,50 @@ exports[`SerialPortSelector should render two ports 1`] = `
   title="Select serial port (Alt+P)">
   <div
     className="padded-row">
-    <DropdownButton
-      className="btn-primary btn-nordic"
-      id="navbar-dropdown"
+    <Dropdown
+      id="serial-port-selector"
       onToggle={[Function]}
-      open={true}
-      title="Select serial port">
-      <MenuItem
-        className="btn-primary"
-        eventKey="/dev/tty0"
-        onSelect={[Function]}>
-        <div>
-          /dev/tty0
-        </div>
-        <div
-          style={
-            Object {
-              "fontSize": "small",
-            }
-          }>
-          123456
-        </div>
-      </MenuItem>
-      <MenuItem
-        className="btn-primary"
-        eventKey="/dev/tty1"
-        onSelect={[Function]}>
-        <div>
-          /dev/tty1
-        </div>
-        <div
-          style={
-            Object {
-              "fontSize": "small",
-            }
-          }>
-          456789
-        </div>
-      </MenuItem>
-    </DropdownButton>
+      open={true}>
+      <DropdownToggle
+        className="serial-port-selector btn-primary btn-nordic"
+        title="Select serial port" />
+      <DropdownMenu
+        className="dropdown-menu-nordic"
+        id="serial-port-selector-list">
+        <MenuItem
+          className="btn-primary"
+          eventKey="/dev/tty0"
+          onSelect={[Function]}>
+          <div>
+            /dev/tty0
+          </div>
+          <div
+            style={
+              Object {
+                "fontSize": "small",
+              }
+            }>
+            123456
+          </div>
+        </MenuItem>
+        <MenuItem
+          className="btn-primary"
+          eventKey="/dev/tty1"
+          onSelect={[Function]}>
+          <div>
+            /dev/tty1
+          </div>
+          <div
+            style={
+              Object {
+                "fontSize": "small",
+              }
+            }>
+            456789
+          </div>
+        </MenuItem>
+      </DropdownMenu>
+    </Dropdown>
     <div
       className="indicator off" />
   </div>
@@ -104,61 +124,66 @@ exports[`SerialPortSelector should render two ports, one selected 1`] = `
   title="Select serial port (Alt+P)">
   <div
     className="padded-row">
-    <DropdownButton
-      className="btn-primary btn-nordic"
-      id="navbar-dropdown"
+    <Dropdown
+      id="serial-port-selector"
       onToggle={[Function]}
-      open={true}
-      title="/dev/tty1">
-      <MenuItem
-        className="btn-primary"
-        eventKey="/dev/tty0"
-        onSelect={[Function]}>
-        <div>
-          /dev/tty0
-        </div>
-        <div
-          style={
-            Object {
-              "fontSize": "small",
-            }
-          }>
-          123456
-        </div>
-      </MenuItem>
-      <MenuItem
-        className="btn-primary"
-        eventKey="/dev/tty1"
-        onSelect={[Function]}>
-        <div>
-          /dev/tty1
-        </div>
-        <div
-          style={
-            Object {
-              "fontSize": "small",
-            }
-          }>
-          456789
-        </div>
-      </MenuItem>
-      <MenuItem
-        className="btn-primary"
-        eventKey="Close serial port"
-        onSelect={[Function]}>
-        <div>
-          Close serial port
-        </div>
-        <div
-          style={
-            Object {
-              "fontSize": "small",
-            }
-          }>
-          
-        </div>
-      </MenuItem>
-    </DropdownButton>
+      open={true}>
+      <DropdownToggle
+        className="serial-port-selector btn-primary btn-nordic"
+        title="/dev/tty1" />
+      <DropdownMenu
+        className="dropdown-menu-nordic"
+        id="serial-port-selector-list">
+        <MenuItem
+          className="btn-primary"
+          eventKey="/dev/tty0"
+          onSelect={[Function]}>
+          <div>
+            /dev/tty0
+          </div>
+          <div
+            style={
+              Object {
+                "fontSize": "small",
+              }
+            }>
+            123456
+          </div>
+        </MenuItem>
+        <MenuItem
+          className="btn-primary"
+          eventKey="/dev/tty1"
+          onSelect={[Function]}>
+          <div>
+            /dev/tty1
+          </div>
+          <div
+            style={
+              Object {
+                "fontSize": "small",
+              }
+            }>
+            456789
+          </div>
+        </MenuItem>
+        <MenuItem
+          className="btn-primary"
+          eventKey="Close serial port"
+          onSelect={[Function]}>
+          <div>
+            Close serial port
+          </div>
+          <div
+            style={
+              Object {
+                "fontSize": "small",
+              }
+            }>
+            
+          </div>
+        </MenuItem>
+      </DropdownMenu>
+    </Dropdown>
     <div
       className="indicator off" />
   </div>

--- a/lib/windows/plugin/containers/MainMenuContainer.js
+++ b/lib/windows/plugin/containers/MainMenuContainer.js
@@ -1,0 +1,60 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import MainMenu from '../components/MainMenu';
+import * as MainMenuActions from '../actions/mainMenuActions';
+import withHotkey from '../../../util/withHotkey';
+import { connect } from '../../../util/plugins';
+
+function mapStateToProps() {
+    return {};
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        menuItems: [{
+            id: 1,
+            text: 'Plugin manager...',
+            hotkey: 'Alt+M',
+            onClick: () => dispatch(MainMenuActions.openPluginManager()),
+        }],
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withHotkey(MainMenu), 'MainMenu');

--- a/resources/css/styles.less
+++ b/resources/css/styles.less
@@ -116,43 +116,26 @@ html, body, #app {
   border-radius: 0px
 }
 
-.dropdown {
-  padding: 0px;
-  border: 0px;
+.serial-port-selector {
   min-width: 143px;
-
-  > .dropdown-toggle {
-    min-width: 143px;
-    padding-right: 20px;
-
-    > .caret {
-      position: absolute;
-      left: 90%;
-      top: 45%;
-    }
-  }
-
-  > .dropdown-menu {
-    background-color: @brand-primary;
-
-    li {
-      a {
-        color: white;
-        background-color: @brand-primary;
-      }
-      a:hover {
-        color: white;
-        background-color: @brand-primary-darker;
-      }
-      a:focus {
-        background-color: @brand-primary-darker;
-      }
-    }
-  }
 }
 
-.dropdown-toggle:focus {
-  outline: 5px auto;
+.dropdown-menu-nordic {
+  background-color: @brand-primary;
+
+  li {
+    a {
+      color: white;
+      background-color: @brand-primary;
+    }
+    a:hover {
+      color: white;
+      background-color: @brand-primary-darker;
+    }
+    a:focus {
+      background-color: @brand-primary-darker;
+    }
+  }
 }
 
 .padded-row-list(@margin: 5px) {
@@ -245,8 +228,4 @@ html, body, #app {
       align-content: flex-end;
       padding: 6px 6px 6px 0px;
   }
-}
-
-.serialSerialnumber {
-    font-size: @font-size-small;
 }

--- a/test/mainMenu-test.js
+++ b/test/mainMenu-test.js
@@ -1,0 +1,65 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { startApplication, stopApplication } from './setup';
+
+let app;
+
+describe('main menu', () => {
+    beforeEach(() => (
+        startApplication()
+            .then(application => {
+                app = application;
+            })
+    ));
+
+    afterEach(() => (
+        stopApplication(app)
+    ));
+
+    it('should not show list of main menu items initially', () => (
+        app.client.windowByIndex(1)
+            .isVisible('#main-menu-list')
+            .then(isVisible => expect(isVisible).toEqual(false))
+    ));
+
+    it('should show a plugin manager menu item when main menu button has been clicked', () => (
+        app.client.windowByIndex(1)
+            .click('#main-menu')
+            .isVisible('#main-menu-list a[title*="Plugin manager"]')
+            .then(isVisible => expect(isVisible).toEqual(true))
+    ));
+});

--- a/test/serialPortSelector-test.js
+++ b/test/serialPortSelector-test.js
@@ -46,14 +46,14 @@ describe('port selector', () => {
             })
     ));
 
-    afterEach(() => {
-        stopApplication(app);
-    });
+    afterEach(() => (
+        stopApplication(app)
+    ));
 
     it('should show port list when port selector has been clicked', () => (
         app.client.windowByIndex(1)
-            .click('#navbar-dropdown')
-            .isVisible('.dropdown-menu')
+            .click('#serial-port-selector')
+            .isVisible('#serial-port-selector-list')
             .then(isVisible => expect(isVisible).toEqual(true))
     ));
 });


### PR DESCRIPTION
Adding a main menu dropdown button in the top-left corner. It currently only contains a "Plugin manager..." item that will open a window for loading/managing plugins. The plugin manager window has not been implemented yet, but is next on the agenda.