### PR TITLE
Select the serial port in case firmware is not to be burned

### DIFF
--- a/lib/components/ConfirmationDialog.jsx
+++ b/lib/components/ConfirmationDialog.jsx
@@ -39,7 +39,9 @@ import React, { PropTypes } from 'react';
 import { Modal, Button, ModalHeader, ModalFooter, ModalBody, ModalTitle } from 'react-bootstrap';
 import Spinner from './Spinner';
 
-const ConfirmationDialog = ({ isVisible, isInProgress, text, onOk, onCancel }) => (
+const ConfirmationDialog = ({
+    isVisible, isInProgress, text, onOk, onCancel, okButtonText, cancelButtonText,
+}) => (
     <div>
         <Modal show={isVisible} onHide={onCancel} backdrop={isInProgress ? 'static' : false}>
             <ModalHeader closeButton={!isInProgress}>
@@ -51,8 +53,8 @@ const ConfirmationDialog = ({ isVisible, isInProgress, text, onOk, onCancel }) =
             <ModalFooter>
                 { isInProgress ? <Spinner /> : null }
                 &nbsp;
-                <Button onClick={onOk} disabled={isInProgress}>OK</Button>
-                <Button onClick={onCancel} disabled={isInProgress}>Cancel</Button>
+                <Button onClick={onOk} disabled={isInProgress}>{okButtonText}</Button>
+                <Button onClick={onCancel} disabled={isInProgress}>{cancelButtonText}</Button>
             </ModalFooter>
         </Modal>
     </div>
@@ -63,11 +65,15 @@ ConfirmationDialog.propTypes = {
     text: PropTypes.string.isRequired,
     onOk: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    okButtonText: PropTypes.string,
+    cancelButtonText: PropTypes.string,
     isInProgress: PropTypes.bool,
 };
 
 ConfirmationDialog.defaultProps = {
     isInProgress: false,
+    okButtonText: 'OK',
+    cancelButtonText: 'Cancel',
 };
 
 export default ConfirmationDialog;

--- a/lib/windows/app/components/FirmwareDialog.jsx
+++ b/lib/windows/app/components/FirmwareDialog.jsx
@@ -47,13 +47,16 @@ const FirmwareDialog = ({
     onCancel,
 }) => {
     if (isVisible) {
-        const textToUse = text || `The development kit on ${port.comName} (${port.serialNumber}) ` +
-            'will be programmed with the required firmware. Would you like to proceed?';
+        const textToUse = text || 'Would you like to program the development kit' +
+            ` on ${port.comName} (${port.serialNumber}) ` +
+            ' with the required firmware?';
         return (
             <ConfirmationDialog
                 isVisible={isVisible}
                 isInProgress={isInProgress}
                 text={textToUse}
+                okButtonText="Yes"
+                cancelButtonText="No"
                 onOk={() => onConfirmUpdateFirmware(port)}
                 onCancel={() => onCancel(port)}
             />

--- a/lib/windows/app/components/FirmwareDialog.jsx
+++ b/lib/windows/app/components/FirmwareDialog.jsx
@@ -55,7 +55,7 @@ const FirmwareDialog = ({
                 isInProgress={isInProgress}
                 text={textToUse}
                 onOk={() => onConfirmUpdateFirmware(port)}
-                onCancel={onCancel}
+                onCancel={() => onCancel(port)}
             />
         );
     }

--- a/lib/windows/app/containers/FirmwareDialogContainer.js
+++ b/lib/windows/app/containers/FirmwareDialogContainer.js
@@ -36,6 +36,7 @@
 
 import FirmwareDialog from '../components/FirmwareDialog';
 import * as FirmwareDialogActions from '../actions/firmwareDialogActions';
+import * as SerialPortActions from '../actions/serialPortActions';
 import withHotkey from '../../../util/withHotkey';
 import { connect } from '../../../util/apps';
 
@@ -52,7 +53,10 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         onConfirmUpdateFirmware: port => dispatch(FirmwareDialogActions.updateFirmware(port)),
-        onCancel: () => dispatch(FirmwareDialogActions.hideDialog()),
+        onCancel: port => {
+            dispatch(FirmwareDialogActions.hideDialog());
+            dispatch(SerialPortActions.selectPort(port));
+        },
     };
 }
 


### PR DESCRIPTION
When user selects a serial port but chooses to cancel the firmware dialog, the serial port is still selected.