### PR TITLE
Add API functions for reading address and family

### DIFF
--- a/lib/api/probe/__tests__/index-test.js
+++ b/lib/api/probe/__tests__/index-test.js
@@ -46,7 +46,7 @@ jest.mock('os', () => ({
 
 import nrfjprog from 'pc-nrfjprog-js';
 import os from 'os';
-import { getVersionInfo, getBaudRate, program, readAddress } from '../index';
+import { getVersionInfo, getBaudRate, program, readAddress, getFamily } from '../index';
 
 const serialNumber = '1337';
 
@@ -224,6 +224,37 @@ describe('probe.readAddress', () => {
         };
         return readAddress(serialNumber).then(dataArray => {
             expect(dataArray).toEqual([1, 2, 3]);
+        });
+    });
+});
+
+describe('probe.getFamily', () => {
+    it('should throw error if serial number cannot be parsed to integer', () => {
+        const invalidSerialNumber = 'foobar';
+        return getFamily(invalidSerialNumber).catch(error => {
+            expect(error.message).toEqual(`Invalid serial number: ${invalidSerialNumber}`);
+        });
+    });
+
+    it('should throw error if DebugProbe returns error', () => {
+        nrfjprog.DebugProbe = class {
+            getFamily(serialNum, callback) {
+                callback(new Error('Foo'));
+            }
+        };
+        return getFamily(serialNumber).catch(error => {
+            expect(error.message).toEqual('Unable to get family. Error: Foo');
+        });
+    });
+
+    it('should return family id if DebugProbe returns family id', () => {
+        nrfjprog.DebugProbe = class {
+            getFamily(serialNum, callback) {
+                callback(null, 1);
+            }
+        };
+        return getFamily(serialNumber).then(familyId => {
+            expect(familyId).toEqual(1);
         });
     });
 });

--- a/lib/api/probe/__tests__/index-test.js
+++ b/lib/api/probe/__tests__/index-test.js
@@ -46,7 +46,7 @@ jest.mock('os', () => ({
 
 import nrfjprog from 'pc-nrfjprog-js';
 import os from 'os';
-import { getVersionInfo, getBaudRate, program } from '../index';
+import { getVersionInfo, getBaudRate, program, readAddress } from '../index';
 
 const serialNumber = '1337';
 
@@ -193,6 +193,37 @@ describe('probe.program', () => {
         const options = {};
         return program(serialNumber, options).catch(error => {
             expect(error.message).toEqual('Unable to program. Error: Foo');
+        });
+    });
+});
+
+describe('probe.readAddress', () => {
+    it('should throw error if serial number cannot be parsed to integer', () => {
+        const invalidSerialNumber = 'foobar';
+        return readAddress(invalidSerialNumber).catch(error => {
+            expect(error.message).toEqual(`Invalid serial number: ${invalidSerialNumber}`);
+        });
+    });
+
+    it('should throw error if DebugProbe returns error', () => {
+        nrfjprog.DebugProbe = class {
+            readAddress(serialNum, address, length, callback) {
+                callback(new Error('Foo'));
+            }
+        };
+        return readAddress(serialNumber).catch(error => {
+            expect(error.message).toEqual('Unable to read address. Error: Foo');
+        });
+    });
+
+    it('should return data array if DebugProbe returns data array', () => {
+        nrfjprog.DebugProbe = class {
+            readAddress(serialNum, address, length, callback) {
+                callback(null, [1, 2, 3]);
+            }
+        };
+        return readAddress(serialNumber).then(dataArray => {
+            expect(dataArray).toEqual([1, 2, 3]);
         });
     });
 });

--- a/lib/api/probe/index.js
+++ b/lib/api/probe/index.js
@@ -80,6 +80,17 @@ function getBaudRate(serialNumber) {
         .then(versionInfo => getBaudRateFromVersionInfo(versionInfo));
 }
 
+/**
+ * Program the given serial number using the provided firmware options. The options
+ * parameter is an object with the following properties:
+ * - 0: {string} firmware hex file path or hex content (if filecontent=true) for nrf51.
+ * - 1: {string} firmware hex file path or hex content (if filecontent=true) for nrf52.
+ * - filecontent: {boolean} true if 0 and/or 1 are hex strings, false if file paths.
+ *
+ * @param {string|int} serialNumber the serial number to use
+ * @param {Object} options firmware options as described above
+ * @returns {Promise} promise that resolves with empty value if successful.
+ */
 function program(serialNumber, options) {
     return new Promise((resolve, reject) => {
         const probe = new DebugProbe();
@@ -93,8 +104,30 @@ function program(serialNumber, options) {
     });
 }
 
+/**
+ * Read 'length' bytes from the provided address, using the given serial number.
+ *
+ * @param {string|int} serialNumber the serial number to use.
+ * @param {int} address the address to read from.
+ * @param {int} length the number of bytes to read.
+ * @returns {Promise} promise that resolves with an integer array if successful.
+ */
+function readAddress(serialNumber, address, length) {
+    return new Promise((resolve, reject) => {
+        const probe = new DebugProbe();
+        probe.readAddress(parseSerialNumber(serialNumber), address, length, (err, data) => {
+            if (err) {
+                reject(new Error(`Unable to read address. Error: ${err.message}`));
+            } else {
+                resolve(data);
+            }
+        });
+    });
+}
+
 export default {
     getVersionInfo,
     getBaudRate,
     program,
+    readAddress,
 };

--- a/lib/api/probe/index.js
+++ b/lib/api/probe/index.js
@@ -125,9 +125,30 @@ function readAddress(serialNumber, address, length) {
     });
 }
 
+/**
+ * Get family for the given serial number. The promise resolves with a family
+ * id; 0 if nrf51 or 1 if nrf52.
+ *
+ * @param {string|int} serialNumber the serial number to use.
+ * @returns {Promise} promise that resolves with family id if successful.
+ */
+function getFamily(serialNumber) {
+    return new Promise((resolve, reject) => {
+        const probe = new DebugProbe();
+        probe.getFamily(parseSerialNumber(serialNumber), (err, familyId) => {
+            if (err) {
+                reject(new Error(`Unable to get family. Error: ${err.message}`));
+            } else {
+                resolve(familyId);
+            }
+        });
+    });
+}
+
 export default {
     getVersionInfo,
     getBaudRate,
     program,
     readAddress,
+    getFamily,
 };

--- a/lib/api/programming/__tests__/index-test.js
+++ b/lib/api/programming/__tests__/index-test.js
@@ -42,7 +42,7 @@ jest.mock('../../../util/apps', () => ({}));
 import path from 'path';
 import probe from '../../probe';
 import apps from '../../../util/apps';
-import { programWithHexFile, programWithHexString } from '../index';
+import { programWithHexFile, programWithHexString, getFamily } from '../index';
 
 const serialNumber = '1337';
 
@@ -143,6 +143,40 @@ describe('programming.programWithHexString', () => {
                 1: '',
                 filecontent: true,
             });
+        });
+    });
+});
+
+describe('programming.getFamily', () => {
+    it('should return error if probe.getFamily() fails', () => {
+        probe.getFamily = () => Promise.reject(new Error('Foo'));
+
+        return getFamily(serialNumber).catch(error => {
+            expect(error.message).toEqual('Foo');
+        });
+    });
+
+    it('should return \'nrf51\' if probe.getFamily() returns 0', () => {
+        probe.getFamily = () => Promise.resolve(0);
+
+        return getFamily(serialNumber).then(family => {
+            expect(family).toEqual('nrf51');
+        });
+    });
+
+    it('should return \'nrf52\' if probe.getFamily() returns 1', () => {
+        probe.getFamily = () => Promise.resolve(1);
+
+        return getFamily(serialNumber).then(family => {
+            expect(family).toEqual('nrf52');
+        });
+    });
+
+    it('should return \'unknown\' if probe.getFamily() returns 2', () => {
+        probe.getFamily = () => Promise.resolve(2);
+
+        return getFamily(serialNumber).then(family => {
+            expect(family).toEqual('unknown');
         });
     });
 });

--- a/lib/api/programming/index.js
+++ b/lib/api/programming/index.js
@@ -118,6 +118,5 @@ export default {
     programWithHexFile,
     programWithHexString,
     getFamily,
-    getVersionInfo: probe.getVersionInfo,
     readAddress: probe.readAddress,
 };

--- a/lib/api/programming/index.js
+++ b/lib/api/programming/index.js
@@ -56,7 +56,7 @@ function getPathRelativeToApp(firmwarePath) {
  * - {boolean} isRelativeToApp: Whether or not paths are relative to the
  *             app directory. Default: true.
  *
- * @param {string} serialNumber The serial number that should be programmed.
+ * @param {string|int} serialNumber The serial number that should be programmed.
  * @param {Object} options Options for programming.
  * @returns {Promise} Promise that resolves if ok, rejects if error.
  */
@@ -83,7 +83,7 @@ function programWithHexFile(serialNumber, options) {
  * - {string} nrf51: Firmware hex content for nRF51.
  * - {string} nrf52: Firmware hex content for nRF52.
  *
- * @param {string} serialNumber The serial number that should be programmed.
+ * @param {string|int} serialNumber The serial number that should be programmed.
  * @param {Object} options Options for programming.
  * @returns {Promise} Promise that resolves if ok, rejects if error.
  */
@@ -95,9 +95,29 @@ function programWithHexString(serialNumber, options) {
     });
 }
 
+/**
+ * Gets the family for the given serial number. The promise resolves with
+ * 'nrf51', 'nrf52', or 'unknown'.
+ *
+ * @param {string|int} serialNumber The serial number to get family for.
+ * @returns {Promise} Promise that resolves with the family name.
+ */
+function getFamily(serialNumber) {
+    return probe.getFamily(serialNumber)
+        .then(familyId => {
+            if (familyId === 0) {
+                return 'nrf51';
+            } else if (familyId === 1) {
+                return 'nrf52';
+            }
+            return 'unknown';
+        });
+}
+
 export default {
     programWithHexFile,
     programWithHexString,
+    getFamily,
     getVersionInfo: probe.getVersionInfo,
     readAddress: probe.readAddress,
 };

--- a/lib/api/programming/index.js
+++ b/lib/api/programming/index.js
@@ -35,7 +35,7 @@
  */
 
 import path from 'path';
-import { getVersionInfo, program } from '../probe';
+import probe from '../probe';
 import { getAppDir } from '../../util/apps';
 
 function getPathRelativeToApp(firmwarePath) {
@@ -67,7 +67,7 @@ function programWithHexFile(serialNumber, options) {
         nrf51Path = getPathRelativeToApp(options.nrf51);
         nrf52Path = getPathRelativeToApp(options.nrf52);
     }
-    return program(serialNumber, {
+    return probe.program(serialNumber, {
         0: nrf51Path || '',
         1: nrf52Path || '',
         filecontent: false,
@@ -88,7 +88,7 @@ function programWithHexFile(serialNumber, options) {
  * @returns {Promise} Promise that resolves if ok, rejects if error.
  */
 function programWithHexString(serialNumber, options) {
-    return program(serialNumber, {
+    return probe.program(serialNumber, {
         0: options.nrf51 || '',
         1: options.nrf52 || '',
         filecontent: true,
@@ -98,5 +98,6 @@ function programWithHexString(serialNumber, options) {
 export default {
     programWithHexFile,
     programWithHexString,
-    getVersionInfo,
+    getVersionInfo: probe.getVersionInfo,
+    readAddress: probe.readAddress,
 };

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "moment": "2.17.1",
         "mousetrap": "1.6.0",
         "pc-ble-driver-js": "https://github.com/NordicSemiconductor/pc-ble-driver-js.git#v1.0.0",
-        "pc-nrfjprog-js": "https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#v0.5.0",
+        "pc-nrfjprog-js": "https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#a742bade",
         "react": "15.4.2",
         "react-bootstrap": "0.30.7",
         "react-dom": "15.4.2",


### PR DESCRIPTION
Making it possible for apps to read devkit family and custom memory addresses for a given serial number. This can be used by apps to detect if the required firmware is present, and not show the firmware dialog if it is not needed.

Example app that reads 10 bytes from address 0 and logs it when the user selects serial port:

```
function readAddress(port) {
    return (dispatch, getState, { programming, logger }) => {
        const address = 0;
        const length = 10;
        programming.readAddress(port.serialNumber, address, length)
            .then(dataArray => logger.info(`Got data: ${dataArray}`));
    };
}

export default {
    mapSerialPortSelectorDispatch: (dispatch, props) => ({
        ...props,
        onSelect: port => dispatch(readAddress(port)),
    }),
};
```