### PR TITLE
Allow apps to set initial state in reduceApp

### DIFF
--- a/lib/windows/app/reducers/__tests__/appReducer-test.js
+++ b/lib/windows/app/reducers/__tests__/appReducer-test.js
@@ -34,17 +34,25 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { decorateReducer } from '../../../util/apps';
+import reducer from '../appReducer';
+import { setApp } from '../../../../util/apps';
 
-// The default appReducer should not do anything. It just returns the same
-// state as it receives. Not setting an initial state here, as that would
-// override the initial state given by the decorated reducer.
-const appReducer = state => state;
+describe('appReducer', () => {
+    it('should have empty object as initial state if reducer has not been decorated', () => {
+        setApp({});
+        const initialState = reducer(undefined, {});
 
-const decoratedAppReducer = decorateReducer(appReducer, 'App');
+        expect(initialState).toEqual({});
+    });
 
-// If the reducer is not decorated, then it will return undefined. Redux does not
-// allow that, so we just return an empty object in that case.
-export default (state, action) => (
-    decoratedAppReducer(state, action) || {}
-);
+    it('should use initial state from app if reducer has been decorated', () => {
+        setApp({
+            reduceApp: (state = { foo: 'bar' }) => ({
+                ...state,
+            }),
+        });
+        const initialState = reducer(undefined, {});
+
+        expect(initialState).toEqual({ foo: 'bar' });
+    });
+});


### PR DESCRIPTION
Apps can implement `reduceApp` to manage their own custom state.

```
export default {
    reduceApp: (state, action) => {
        /* reducer logic */
    },
};
```

Normally, Redux reducers receive `undefined` as state when invoked for the first time. This is commonly used as a convention for specifying the initial state, like this:

```
export default {
    reduceApp: (state = { foo: 'bar' }, action) => {
        /* reducer logic */
    },
};
```

This did not work for `reduceApp`. It received `{}` as state when invoked for the first time, which made it difficult for apps to set their own initial state. This has now been fixed so that state is `undefined` on the first invocation.