### PR TITLE
Add wrapper for installing apps using yarn

### DIFF
--- a/lib/api/yarn/__tests__/parsing-test.jsx
+++ b/lib/api/yarn/__tests__/parsing-test.jsx
@@ -1,0 +1,67 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { parseOutdated } from '../parsing';
+
+describe('parseOutdated', () => {
+    it('should return empty object if yarn output is empty', () => {
+        expect(parseOutdated('')).toEqual({});
+    });
+
+    it('should return empty object if yarn output contains irrelevant output', () => {
+        const yarnOutput = `warning No license field
+Done in 0.23s.`;
+        expect(parseOutdated(yarnOutput)).toEqual({});
+    });
+
+    it('should return object with two packages if output contains two outdated dependencies', () => {
+        const yarnOutput = `warning No license field
+Package        Current    Wanted    Latest    Package Type
+mypackage1     1.2.3      1.2.3     1.2.4     dependencies
+mypackage2     4.5.6      4.5.6     5.0.0     dependencies
+Done in 0.23s.`;
+        expect(parseOutdated(yarnOutput)).toEqual({
+            mypackage1: {
+                currentVersion: '1.2.3',
+                latestVersion: '1.2.4',
+            },
+            mypackage2: {
+                currentVersion: '4.5.6',
+                latestVersion: '5.0.0',
+            },
+        });
+    });
+});

--- a/lib/api/yarn/index.js
+++ b/lib/api/yarn/index.js
@@ -1,0 +1,118 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { fork } from 'child_process';
+import { getAppsRootDir } from '../../util/fileUtil';
+import { parseOutdated } from './parsing';
+
+const yarnPath = window.require.resolve('yarn/bin/yarn.js');
+
+function yarn(args, options = {}) {
+    return new Promise((resolve, reject) => {
+        const proc = fork(yarnPath, args, {
+            ...options,
+            cwd: getAppsRootDir(),
+            stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        });
+
+        let buffer = '';
+        const addToBuffer = data => {
+            buffer += data.toString();
+        };
+        proc.stdout.on('data', data => addToBuffer(data));
+        proc.stderr.on('data', data => addToBuffer(data));
+
+        proc.on('exit', code => (
+            code !== 0 ? reject(buffer) : resolve(buffer)
+        ));
+        proc.on('error', err => (
+            reject(`Error when running yarn: ${err.message}`)
+        ));
+    });
+}
+
+/**
+ * Installs the given npm package in the apps root directory. The package
+ * is added as an exact dependency in package.json in the same directory.
+ * The name can optionally have a version, e.g. 'package@1.2.3'.
+ *
+ * @param {string} name The name of the package to install.
+ * @returns {Promise} Promise that resolves or rejects with the yarn output.
+ */
+function install(name) {
+    return yarn(['add', '--exact', name]);
+}
+
+/**
+ * Uninstalls the given npm package in the apps root directory. The package
+ * is removed from the list of dependencies in package.json in the same
+ * directory.
+ *
+ * @param {string} name The name of the package to remove.
+ * @returns {Promise} Promise that resolves or rejects with the yarn output.
+ */
+function uninstall(name) {
+    return yarn(['remove', name]);
+}
+
+/**
+ * Returns packages that have outdated versions. A promise is returned,
+ * which resolves with an object containing package names as keys and
+ * currentVersion and latestVersion as values. E.g:
+ *
+ * {
+ *   name: {
+ *     currentVersion: '1.2.3',
+ *     latestVersion: '1.2.4',
+ *   },
+ *   ...
+ * }
+ *
+ * If no outdated packages are found, the promise will resolve with an
+ * empty object.
+ *
+ * @returns {Promise} Promise that resolves with an object of packages.
+ */
+function outdated() {
+    return yarn(['outdated'])
+        .then(output => parseOutdated(output));
+}
+
+export default {
+    install,
+    uninstall,
+    outdated,
+};

--- a/lib/api/yarn/parsing.js
+++ b/lib/api/yarn/parsing.js
@@ -1,0 +1,58 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+function parseOutdated(yarnOutput) {
+    return yarnOutput
+        .split(/\r?\n/)
+        .map(line => line.split(/\s+/))
+        .filter(lineArray => lineArray.length > 4 && lineArray[4] === 'dependencies')
+        .reduce((result, lineArray) => {
+            const name = lineArray[0];
+            const currentVersion = lineArray[1];
+            const latestVersion = lineArray[3];
+            return {
+                ...result,
+                [name]: {
+                    currentVersion,
+                    latestVersion,
+                },
+            };
+        }, {});
+}
+
+export default {
+    parseOutdated,
+};

--- a/lib/util/fileUtil.js
+++ b/lib/util/fileUtil.js
@@ -192,6 +192,7 @@ function openFileInDefaultApplication(filePath, callback) {
 
 export default {
     getHomeDir,
+    getAppsRootDir,
     getAppLocalDir,
     listDirectories,
     readPackageJson,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
         "redux-thunk": "2.2.0",
         "serialport": "4.0.7",
         "winston": "2.3.1",
-        "yargs": "7.0.2"
+        "yargs": "7.0.2",
+        "yarn": "0.21.3"
     },
     "jest": {
         "moduleNameMapper": {


### PR DESCRIPTION
We are going to add a UI for installing/removing apps. The apps will be published on npmjs.org, which means that we can use npm or yarn to manage packages. The plan is to have the following directory structure in the user's home directory:

```
~/.nrfconnect-apps
├── local                   # Used during development, or for unofficial apps
|   └── pc-nrfconnect-foo
├── node_modules            # Installed npm packages, as specified by package.json
│   ├── pc-nrfconnect-ble
│   └── pc-nrfconnect-rssi
├── package.json            # Specifies which apps we have installed, and their version
└── apps.json               # List of official apps that may be installed
```

This PR adds the possibility to install, remove, upgrade, and check for updates for npm packages in the ~/.nrfconnect-apps directory. Installed apps are added to ~/.nrfconnect-apps/package.json. This means that we can keep track of installed apps and their versions. Yarn has a nice 'outdated' command that we use to figure out which apps may be upgraded.

I tried using npm first, but it turned out to be difficult to use programmatically. It has an API, but it is undocumented and not intended for external use. Yarn turned out to be a lot easier to use. In addition, the size of the yarn dependency is smaller than npm, and it should also be faster.