### PR TITLE
Fix path separator issue when reading app info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules
+/node_modules
 .idea
 dist
 jest.json

--- a/main/apps.js
+++ b/main/apps.js
@@ -161,9 +161,10 @@ function initAppsDirectory() {
  * @returns {Promise} promise that resolves with app info.
  */
 function readAppInfo(appPath) {
-    return fileUtil.readJsonFile(`${appPath}/package.json`)
+    const packageJsonPath = path.join(appPath, 'package.json');
+    return fileUtil.readJsonFile(packageJsonPath)
         .then(packageJson => {
-            const iconPath = `${appPath}/icon.png`;
+            const iconPath = path.join(appPath, 'icon.png');
             return {
                 name: packageJson.name,
                 displayName: packageJson.displayName,

--- a/test/features/one-local-app/node_modules/.gitignore
+++ b/test/features/one-local-app/node_modules/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/test/features/one-official-app-installed/node_modules/pc-nrfconnect-test/index.js
+++ b/test/features/one-official-app-installed/node_modules/pc-nrfconnect-test/index.js
@@ -1,0 +1,37 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+module.exports = {};

--- a/test/features/one-official-app-installed/node_modules/pc-nrfconnect-test/package.json
+++ b/test/features/one-official-app-installed/node_modules/pc-nrfconnect-test/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "pc-nrfconnect-test",
+    "version": "1.2.3",
+    "displayName": "Test App"
+}

--- a/test/features/one-official-app-not-installed/node_modules/.gitignore
+++ b/test/features/one-official-app-not-installed/node_modules/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/test/features/one-official-app-upgradable/node_modules/pc-nrfconnect-test/index.js
+++ b/test/features/one-official-app-upgradable/node_modules/pc-nrfconnect-test/index.js
@@ -1,0 +1,37 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+module.exports = {};

--- a/test/features/one-official-app-upgradable/node_modules/pc-nrfconnect-test/package.json
+++ b/test/features/one-official-app-upgradable/node_modules/pc-nrfconnect-test/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "pc-nrfconnect-test",
+    "version": "1.2.3",
+    "displayName": "Test App"
+}


### PR DESCRIPTION
Fixed some incorrect path separators in `main/apps.js`.

Also, now only excluding `node_modules` in the root of the repo. There are some node_modules directories below `test/` that are needed for integration tests, so added those.