### PR TITLE
Avoid issues with multiple copies of react and react-redux

### DIFF
--- a/lib/windows/app/index.js
+++ b/lib/windows/app/index.js
@@ -37,12 +37,31 @@
 import 'babel-polyfill';
 
 import React from 'react';
+import * as ReactRedux from 'react-redux';
 import { render } from 'react-dom';
+import Module from 'module';
 import RootContainer from './containers/RootContainer';
 import configureStore from '../../store/configureStore';
 import { loadApp } from '../../util/apps';
 import rootReducer from './reducers';
 import '../../../resources/css/app.less';
+
+/*
+ * The loaded app may import react and react-redux. We must make sure that the
+ * app uses the same instances of react and react-redux as we have in core.
+ * Cannot have multiple copies of these loaded at the same time.
+ */
+const originalLoad = Module._load;   // eslint-disable-line no-underscore-dangle
+Module._load = function load(path) { // eslint-disable-line no-underscore-dangle
+    switch (path) {
+        case 'react':
+            return React;
+        case 'react-redux':
+            return ReactRedux;
+        default:
+            return originalLoad.apply(this, arguments); // eslint-disable-line prefer-rest-params
+    }
+};
 
 const params = new URL(window.location).searchParams;
 const appPath = params.get('appPath');


### PR DESCRIPTION
As apps exist outside of core, they cannot import modules from core's node_modules directory. What happens when apps do 'import React from "react"' is that it tries to load react from the app's node_modules directory.

One might think that this would work as long as the app actually has react as a dependency. However, if core loads react from its node_modules directory, and the app loads react from a different node_modules directory, react will complain about multiple copies of react being loaded at the same time. A similar issue happens with react-redux.

To fix this, we must make sure that the imported react and react-redux instances are the same for both core and the app. Monkey patching Module._load isn't pretty, but I have not been able to find a better way to do it. Got the idea from the Hyperterm source code.