### PR TITLE
Not show firmware dialog by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,53 +300,6 @@ nRF Connect respects the `main` field in the app's package.json, so the entry fi
   </tbody>
 </table>
 
-#### Properties
-
-<table>
-  <tbody>
-    <tr>
-      <th>Property</th>
-      <th>Description</th>
-    </tr>
-    <tr>
-      <td>
-        <code>config</code><br />
-      </td>
-      <td>
-        <p>Property that is used for general configuration. This can be added to the app object, similar to the methods, and supports the settings described below.</p>
-        <table>
-          <tbody>
-            <tr>
-              <td><code>firmwareData</code></td>
-              <td>
-                <p>Firmware hex string to program when user selects serial port.</p>
-                <p>Must be an object that has one (or both) of the following properties:</p>
-                <pre>{
-  nrf51: 'nrf51-hex-string',
-  nrf52: 'nrf52-hex-string',
-}</pre>
-                <p>Note that <code>firmwareData</code> and <code>firmwarePaths</code> should not be used simultaneously.</p>
-              </td>
-            </tr>
-            <tr>
-              <td><code>firmwarePaths</code></td>
-              <td>
-                <p>Paths to firmware hex files to program when user selects serial port. Paths are relative to the app's root directory.</p>
-                <p>Must be an object that has one (or both) of the following properties:</p>
-                <pre>{
-  nrf51: './path/to/nrf51-firmware.hex',
-  nrf52: './path/to/nrf52-firmware.hex',
-}</pre>
-                <p>Note that <code>firmwareData</code> and <code>firmwarePaths</code> should not be used simultaneously.</p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 #### API operations
 
 When implementing the `map*Dispatch` methods, apps can create and dispatch custom actions. When dispatching actions, the action creator get access to an `api` object that enables using the logger, serial ports, BLE, and programming. Below is an example that adds a log message when the user selects a serial port.

--- a/lib/util/__tests__/apps-test.jsx
+++ b/lib/util/__tests__/apps-test.jsx
@@ -377,17 +377,3 @@ describe('decorateReducer', () => {
         });
     });
 });
-
-describe('getAppConfig', () => {
-    it('should throw error if app has no \'config\' property', () => {
-        setApp({});
-        expect(() => getAppConfig()).toThrow();
-    });
-
-    it('should return \'config\' property if provided by app', () => {
-        setApp({
-            config: { foo: 'bar' },
-        });
-        expect(getAppConfig()).toEqual({ foo: 'bar' });
-    });
-});

--- a/lib/util/apps.js
+++ b/lib/util/apps.js
@@ -75,23 +75,6 @@ function setApp(appObj) {
 }
 
 /**
- * Get the 'config' property of the currently loaded app.
- *
- * @throws Will throw error if app is not loaded or does not have 'config'.
- * @returns {Object} The app config object.
- */
-function getAppConfig() {
-    if (!app) {
-        throw new Error('Tried to get app configuration, but no app is loaded.');
-    }
-    if (!app.config) {
-        throw new Error('Tried to get app configuration, but app does not have a ' +
-            '\'config\' property.');
-    }
-    return app.config;
-}
-
-/**
  * Get the filesystem path of the currently loaded app.
  *
  * @returns {string|undefined} Absolute path of current app.
@@ -235,6 +218,5 @@ export default {
     decorateReducer,
     decorate,
     connect,
-    getAppConfig,
     getAppDir,
 };

--- a/lib/windows/app/actions/firmwareDialogActions.js
+++ b/lib/windows/app/actions/firmwareDialogActions.js
@@ -34,26 +34,9 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { programming, logger } from '../../../api';
-import { getAppConfig } from '../../../util/apps';
-import * as SerialPortActions from './serialPortActions';
-
 export const FIRMWARE_DIALOG_SHOW = 'FIRMWARE_DIALOG_SHOW';
 export const FIRMWARE_DIALOG_HIDE = 'FIRMWARE_DIALOG_HIDE';
 export const FIRMWARE_DIALOG_UPDATE_REQUESTED = 'FIRMWARE_DIALOG_UPDATE_REQUESTED';
-export const FIRMWARE_DIALOG_UPDATE_SUCCESS = 'FIRMWARE_DIALOG_UPDATE_SUCCESS';
-export const FIRMWARE_DIALOG_UPDATE_ERROR = 'FIRMWARE_DIALOG_UPDATE_ERROR';
-
-function program(serialNumber) {
-    const config = getAppConfig();
-    if (config.firmwareData) {
-        return programming.programWithHexString(serialNumber, config.firmwareData);
-    } else if (config.firmwarePaths) {
-        return programming.programWithHexFile(serialNumber, config.firmwarePaths);
-    }
-    return Promise.reject(new Error('None of \'config.firmwareData\' or \'config.firmwarePaths\'' +
-        ' were provided by app.'));
-}
 
 export function showDialog(port) {
     return {
@@ -68,36 +51,9 @@ export function hideDialog() {
     };
 }
 
-export function firmwareUpdateRequested() {
+export function firmwareUpdateRequested(port) {
     return {
         type: FIRMWARE_DIALOG_UPDATE_REQUESTED,
-    };
-}
-
-export function firmwareUpdateSuccess() {
-    return {
-        type: FIRMWARE_DIALOG_UPDATE_SUCCESS,
-    };
-}
-
-export function firmwareUpdateError(message) {
-    return {
-        type: FIRMWARE_DIALOG_UPDATE_ERROR,
-        message,
-    };
-}
-
-export function updateFirmware(port) {
-    return dispatch => {
-        dispatch(firmwareUpdateRequested());
-        program(port.serialNumber)
-            .then(() => {
-                dispatch(firmwareUpdateSuccess());
-                dispatch(SerialPortActions.selectPort(port));
-            })
-            .catch(error => {
-                logger.error(`Unable to update firmware for ${port.serialNumber}: ${error.message}`);
-                dispatch(firmwareUpdateError(error.message));
-            });
+        port,
     };
 }

--- a/lib/windows/app/containers/FirmwareDialogContainer.js
+++ b/lib/windows/app/containers/FirmwareDialogContainer.js
@@ -52,10 +52,12 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        onConfirmUpdateFirmware: port => dispatch(FirmwareDialogActions.updateFirmware(port)),
-        onCancel: port => {
+        onConfirmUpdateFirmware: port => (
+            dispatch(FirmwareDialogActions.firmwareUpdateRequested(port))
+        ),
+        onCancel: () => {
+            dispatch(SerialPortActions.deselectPort());
             dispatch(FirmwareDialogActions.hideDialog());
-            dispatch(SerialPortActions.selectPort(port));
         },
     };
 }

--- a/lib/windows/app/containers/SerialPortSelectorContainer.js
+++ b/lib/windows/app/containers/SerialPortSelectorContainer.js
@@ -36,7 +36,6 @@
 
 import SerialPortSelector from '../components/SerialPortSelector';
 import * as SerialPortActions from '../actions/serialPortActions';
-import * as FirmwareDialogActions from '../actions/firmwareDialogActions';
 import withHotkey from '../../../util/withHotkey';
 import { connect } from '../../../util/apps';
 
@@ -53,7 +52,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        onSelect: port => dispatch(FirmwareDialogActions.showDialog(port)),
+        onSelect: port => dispatch(SerialPortActions.selectPort(port)),
         onDeselect: () => dispatch(SerialPortActions.deselectPort()),
         toggleExpanded: () => dispatch(SerialPortActions.toggleSelectorExpanded()),
     };

--- a/lib/windows/app/reducers/__tests__/firmwareDialogReducer-test.js
+++ b/lib/windows/app/reducers/__tests__/firmwareDialogReducer-test.js
@@ -34,17 +34,13 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* eslint-disable import/first */
-
-jest.mock('../../../../api', () => {});
-
 import reducer from '../firmwareDialogReducer';
 import * as FirmwareDialogActions from '../../actions/firmwareDialogActions';
 
 const initialState = reducer(undefined, {});
 
 describe('firmwareDialogReducer', () => {
-    it('should be hidden by default', () => {
+    it('should be hidden, with no port, and not in progress by default', () => {
         expect(initialState.isVisible).toEqual(false);
     });
 
@@ -58,19 +54,6 @@ describe('firmwareDialogReducer', () => {
         expect(state.port.toJS()).toEqual(port);
     });
 
-    it('should not be visible and not have a port object after hide action has been dispatched', () => {
-        const port = { comName: '/dev/tty1' };
-        const firstState = reducer(initialState, {
-            type: FirmwareDialogActions.FIRMWARE_DIALOG_SHOW,
-            port,
-        });
-        const secondState = reducer(firstState, {
-            type: FirmwareDialogActions.FIRMWARE_DIALOG_HIDE,
-        });
-        expect(secondState.isVisible).toEqual(false);
-        expect(secondState.port).toEqual(null);
-    });
-
     it('should have isInProgress true after firmware update action has been dispatched', () => {
         const state = reducer(initialState, {
             type: FirmwareDialogActions.FIRMWARE_DIALOG_UPDATE_REQUESTED,
@@ -78,7 +61,7 @@ describe('firmwareDialogReducer', () => {
         expect(state.isInProgress).toEqual(true);
     });
 
-    it('should have initial state after firmware update has succeeded', () => {
+    it('should be hidden, with no port, and not in progress after hide action has been dispatched', () => {
         const port = { comName: '/dev/tty1' };
         const firstState = reducer(initialState, {
             type: FirmwareDialogActions.FIRMWARE_DIALOG_SHOW,
@@ -88,23 +71,10 @@ describe('firmwareDialogReducer', () => {
             type: FirmwareDialogActions.FIRMWARE_DIALOG_UPDATE_REQUESTED,
         });
         const thirdState = reducer(secondState, {
-            type: FirmwareDialogActions.FIRMWARE_DIALOG_UPDATE_SUCCESS,
+            type: FirmwareDialogActions.FIRMWARE_DIALOG_HIDE,
         });
-        expect(thirdState).toEqual(initialState);
-    });
-
-    it('should have initial state after firmware update has failed', () => {
-        const port = { comName: '/dev/tty1' };
-        const firstState = reducer(initialState, {
-            type: FirmwareDialogActions.FIRMWARE_DIALOG_SHOW,
-            port,
-        });
-        const secondState = reducer(firstState, {
-            type: FirmwareDialogActions.FIRMWARE_DIALOG_UPDATE_REQUESTED,
-        });
-        const thirdState = reducer(secondState, {
-            type: FirmwareDialogActions.FIRMWARE_DIALOG_UPDATE_ERROR,
-        });
-        expect(thirdState).toEqual(initialState);
+        expect(thirdState.isVisible).toEqual(false);
+        expect(thirdState.isInProgress).toEqual(false);
+        expect(thirdState.port).toEqual(null);
     });
 });

--- a/lib/windows/app/reducers/firmwareDialogReducer.js
+++ b/lib/windows/app/reducers/firmwareDialogReducer.js
@@ -52,22 +52,14 @@ function showDialog(state, port) {
         .set('isVisible', true);
 }
 
-function hideDialog(state) {
-    return state.set('port', null)
-        .set('isVisible', false);
-}
-
 const reducer = (state = initialState, action) => {
     switch (action.type) {
         case FirmwareDialogActions.FIRMWARE_DIALOG_SHOW:
             return showDialog(state, action.port);
         case FirmwareDialogActions.FIRMWARE_DIALOG_HIDE:
-            return hideDialog(state);
+            return initialState;
         case FirmwareDialogActions.FIRMWARE_DIALOG_UPDATE_REQUESTED:
             return state.set('isInProgress', true);
-        case FirmwareDialogActions.FIRMWARE_DIALOG_UPDATE_SUCCESS:
-        case FirmwareDialogActions.FIRMWARE_DIALOG_UPDATE_ERROR:
-            return initialState;
         default:
             return state;
     }


### PR DESCRIPTION
Up until now, core has opened the firmware dialog when selecting serial port, and done programming based on `config.firmware*` settings provided by the app. The intention behind this was to make things easy for apps, and to provide a common default. However, I see some problems with this approach:

- A common use case is to only show the firmware dialog if programming is necessary. Then the apps most likely have to override the default anyway.
- When selecting serial port, I would expect the `SERIAL_PORT_SELECTED` action to be dispatched, but it is currently dispatching `FIRMWARE_DIALOG_SHOW`. This may be confusing.
- We have had some discussions lately on what core should do and not do, and @CoqRogue argued that core should be simple, and not add extra logic on top of external libraries such as pc-nrfjprog-js. These should just be "plugged in" and not affect the code in core. I agree on this.

Because of this, I suggest modifying the firmware/programming behavior like this:

- When selecting serial port now, the `SERIAL_PORT_SELECTED` action is dispatched, and the port is selected in the dropdown. The apps can listen to this action and implement their own logic.
- The apps must now call the programming API with the firmware they want to program.
- The `config` property has been removed, as the `firmwareData`/`firmwarePaths` is not in use anymore. The property could easily be re-added later if necessary.

I have tested with the RSSI app, and made the following adjustments to accomodate the change in core: https://github.com/NordicSemiconductor/pc-nrfconnect-rssi/commit/1ac16a07