### PR TITLE
Explicitly tell electron-builder to not publish artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "clean-dist": "rimraf dist",
         "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\"",
         "get-nrfjprog": "node build/get-nrfjprog.js",
-        "pack": "npm run build && npm run get-nrfjprog && build"
+        "pack": "npm run build && npm run get-nrfjprog && build -p never"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "Proprietary",


### PR DESCRIPTION
When electron-builder detects that it is running on a CI server, it will use publishing configuration `onTagOrDraft`, ref: https://github.com/electron-userland/electron-builder/wiki/Publishing-Artifacts#cli-flags.

When `onTagOrDraft` is enabled, it tries to connect to GitHub to see if there is a draft release. If that is the case, the artifacts are added to the draft release. This may be useful in the future, but right now we do not have a GitHub token set up on the build server, so connecting to GitHub fails. Switching publishing off until we are ready to publish.