### PR TITLE
Refer to pc-ble-driver-js master during development

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "immutable": "3.8.1",
         "moment": "2.17.1",
         "mousetrap": "1.6.0",
-        "pc-ble-driver-js": "https://github.com/NordicSemiconductor/pc-ble-driver-js.git#v1.0.0",
+        "pc-ble-driver-js": "https://github.com/NordicSemiconductor/pc-ble-driver-js.git#master",
         "pc-nrfjprog-js": "https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#a742bade",
         "react": "15.4.2",
         "react-bootstrap": "0.30.7",


### PR DESCRIPTION
Changing to depend on the master branch of pc-ble-driver-js while we are working on nRF Connect 2.0. This branch contains some new features, such as getting firmware path/content.

The pc-ble-driver-js master branch will be tagged with a new version before release, so we should update this dependency when that time comes.