### PR TITLE
Copy nrfjprog libs to electron directory in node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ Run end-to-end tests:
 
     npm run test-e2e
 
+## Creating release artifacts
+
+To pack nRF Connect into a release artifact for the current platform:
+
+    npm run pack
+
+Depending on the platform, this will create:
+
+* Windows: NSIS installer
+* macOS: DMG disk image
+* Linux: tar.gz archive
+
 ## Creating apps
 
 **Note: The API for apps is in development and may change before the final release.**

--- a/README.md
+++ b/README.md
@@ -96,12 +96,6 @@ Download and install the latest [nRF5x-Command-Line-Tools](https://www.nordicsem
 
 J-Link driver needs to be separately installed on Linux and macOS, download and install appropriate package for your operating system from [SEGGER](https://www.segger.com/downloads/jlink) under the section *J-Link Software and Documentation Pack*.
 
-To set up nrfjprog so that it is available during development on Linux or macOS, run the following:
-
-    npm run get-nrfjprog && cp build/nrfjprog/unpacked/nrfjprog/* node_modules/electron/dist
-
-This will download and put the nrfjprog libraries in the same directory as the electron binary in node_modules, so that the application finds them.
-
 ## Testing
 
 Run unit tests:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "main": "index.js",
     "scripts": {
         "start": "echo 'please run `npm run dev` in one tab and then `npm run app` in another one'",
+        "postinstall": "npm run get-nrfjprog",
         "app": "electron .",
         "dev": "webpack --watch",
         "webpack": "webpack",
@@ -21,7 +22,7 @@
         "clean-dist": "rimraf dist",
         "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\"",
         "get-nrfjprog": "node build/get-nrfjprog.js",
-        "pack": "npm run build && npm run get-nrfjprog && build -p never"
+        "pack": "npm run build && build -p never"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "Proprietary",


### PR DESCRIPTION
This replaces the manual `npm run get-nrfjprog && cp ...` step that was previously required on Linux and macOS. Now the nrfjprog libraries are set up automatically after `npm install`.