### PR TITLE
Upgrade to yarn 0.24.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "serialport": "4.0.7",
         "winston": "2.3.1",
         "yargs": "7.0.2",
-        "yarn": "0.21.3"
+        "yarn": "0.24.2"
     },
     "jest": {
         "moduleNameMapper": {


### PR DESCRIPTION
Our current version of yarn caches each module it requires. When it runs, it stores a map of required paths, with their corresponding location on the file system. It uses a library called roadrunner for doing this, and the file is put in the user's home directory.

This causes problems for us, as when we release new versions of nRF Connect, the modules can be shuffled around, and the yarn cache ends up being invalid.

In the version 0.24.x of yarn, it appears that roadrunner has been removed. Upgrading, so that we can avoid this caching issue.