### PR TITLE
Auto update for Windows and macOS

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,13 +1,21 @@
 !macro customInstall
-  ; Add Visual C++ Redistributable for Visual Studio 2015
+
+  ; Adding Visual C++ Redistributable for Visual Studio 2015
   File "${BUILD_RESOURCES_DIR}\vc_redist_2015.x86.exe"
 
-  ; Add nRF5x-Command-Line-Tools installer (downloaded by 'npm run get-nrfjprog')
-  File "${BUILD_RESOURCES_DIR}\nrfjprog\nrfjprog-win32.exe"
-
-  ; Run installer and wait before continuing
+  ; Running installer and waiting before continuing
   ExecWait '"$INSTDIR\vc_redist_2015.x86.exe" /passive /norestart'
 
-  ; Run installer and wait before continuing
-  ExecWait '"$INSTDIR\nrfjprog-win32.exe" /passive /norestart'
+  ; Checking if we have nrfjprog installed, ref:
+  ; https://nsis-dev.github.io/NSIS-Forums/html/t-288318.html
+  ClearErrors
+  EnumRegKey $0 HKLM "SOFTWARE\Nordic Semiconductor\nrfjprog" 0
+  IfErrors 0 keyexist
+    ; Adding nRF5x-Command-Line-Tools installer (downloaded by 'npm run get-nrfjprog')
+    File "${BUILD_RESOURCES_DIR}\nrfjprog\nrfjprog-win32.exe"
+
+    ; Running installer and waiting before continuing
+    ExecWait '"$INSTDIR\nrfjprog-win32.exe" /passive /norestart'
+  keyexist:
+
 !macroend

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ const apps = require('./main/apps');
 const browser = require('./main/browser');
 const settings = require('./main/settings');
 const createMenu = require('./main/menu').createMenu;
-const packageJson = require('./package.json');
 
 const electronApp = electron.app;
 const Menu = electron.Menu;
@@ -64,7 +63,7 @@ const appWindows = [];
 
 function openLauncherWindow() {
     launcherWindow = browser.createWindow({
-        title: `nRF Connect v${packageJson.version}`,
+        title: `nRF Connect v${config.getVersion()}`,
         url: `file://${__dirname}/resources/launcher.html`,
         icon: `${__dirname}/resources/nrfconnect.png`,
         width: 670,
@@ -84,7 +83,7 @@ function openLauncherWindow() {
 function openAppWindow(app) {
     const lastWindowState = settings.loadLastWindow();
     const appWindow = browser.createWindow({
-        title: `nRF Connect v${packageJson.version} - ${app.displayName || app.name}`,
+        title: `nRF Connect v${config.getVersion()} - ${app.displayName || app.name}`,
         url: `file://${__dirname}/resources/app.html?appPath=${app.path}`,
         icon: app.iconPath ? app.iconPath : `${__dirname}/resources/nrfconnect.png`,
         x: lastWindowState.x,

--- a/lib/components/ConfirmationDialog.jsx
+++ b/lib/components/ConfirmationDialog.jsx
@@ -40,12 +40,12 @@ import { Modal, Button, ModalHeader, ModalFooter, ModalBody, ModalTitle } from '
 import Spinner from './Spinner';
 
 const ConfirmationDialog = ({
-    isVisible, isInProgress, text, onOk, onCancel, okButtonText, cancelButtonText,
+    isVisible, isInProgress, title, text, onOk, onCancel, okButtonText, cancelButtonText,
 }) => (
     <div>
         <Modal show={isVisible} onHide={onCancel} backdrop={isInProgress ? 'static' : false}>
             <ModalHeader closeButton={!isInProgress}>
-                <ModalTitle>Confirm</ModalTitle>
+                <ModalTitle>{title}</ModalTitle>
             </ModalHeader>
             <ModalBody>
                 <p>{text}</p>
@@ -62,6 +62,7 @@ const ConfirmationDialog = ({
 
 ConfirmationDialog.propTypes = {
     isVisible: PropTypes.bool.isRequired,
+    title: PropTypes.string,
     text: PropTypes.string.isRequired,
     onOk: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
@@ -71,6 +72,7 @@ ConfirmationDialog.propTypes = {
 };
 
 ConfirmationDialog.defaultProps = {
+    title: 'Confirm',
     isInProgress: false,
     okButtonText: 'OK',
     cancelButtonText: 'Cancel',

--- a/lib/windows/launcher/actions/autoUpdateActions.js
+++ b/lib/windows/launcher/actions/autoUpdateActions.js
@@ -1,0 +1,159 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { remote } from 'electron';
+import log from 'electron-log';
+import * as ErrorDialogActions from '../../../actions/errorDialogActions';
+
+export const AUTO_UPDATE_CHECK = 'AUTO_UPDATE_CHECK';
+export const AUTO_UPDATE_AVAILABLE = 'AUTO_UPDATE_AVAILABLE';
+export const AUTO_UPDATE_POSTPONE = 'AUTO_UPDATE_POSTPONE';
+export const AUTO_UPDATE_START_DOWNLOAD = 'AUTO_UPDATE_START_DOWNLOAD';
+export const AUTO_UPDATE_CANCEL_DOWNLOAD = 'AUTO_UPDATE_CANCEL_DOWNLOAD';
+export const AUTO_UPDATE_DOWNLOAD_CANCELLED = 'AUTO_UPDATE_DOWNLOAD_CANCELLED';
+export const AUTO_UPDATE_DOWNLOADING = 'AUTO_UPDATE_DOWNLOADING';
+export const AUTO_UPDATE_ERROR = 'AUTO_UPDATE_ERROR';
+
+const { autoUpdater, CancellationToken } = remote.require('./main/autoUpdate');
+const cancellationToken = new CancellationToken();
+const isWindows = process.platform === 'win32';
+
+function checkAction() {
+    return {
+        type: AUTO_UPDATE_CHECK,
+    };
+}
+
+function updateAvailableAction(version) {
+    return {
+        type: AUTO_UPDATE_AVAILABLE,
+        version,
+    };
+}
+
+function startDownloadAction() {
+    return {
+        type: AUTO_UPDATE_START_DOWNLOAD,
+        isProgressSupported: isWindows,
+        isCancelSupported: isWindows,
+    };
+}
+
+function cancelDownloadAction() {
+    return {
+        type: AUTO_UPDATE_CANCEL_DOWNLOAD,
+    };
+}
+
+function downloadCancelledAction() {
+    return {
+        type: AUTO_UPDATE_DOWNLOAD_CANCELLED,
+    };
+}
+
+function updateDownloadingAction(percentDownloaded) {
+    return {
+        type: AUTO_UPDATE_DOWNLOADING,
+        percentDownloaded,
+    };
+}
+
+function updateErrorAction(error) {
+    return {
+        type: AUTO_UPDATE_ERROR,
+        error,
+    };
+}
+
+export function postponeUpdate() {
+    return {
+        type: AUTO_UPDATE_POSTPONE,
+    };
+}
+
+export function checkForUpdates() {
+    return dispatch => {
+        dispatch(checkAction());
+
+        const checkForUpdatesPromise = autoUpdater.checkForUpdates();
+        if (!checkForUpdatesPromise) {
+            log.warn('Not able to auto-update. Unsupported platform.');
+            return;
+        }
+
+        checkForUpdatesPromise
+            .then(result => {
+                if (autoUpdater.updateAvailable) {
+                    dispatch(updateAvailableAction(result.versionInfo.version));
+                }
+            })
+            .catch(error => {
+                dispatch(updateErrorAction(error));
+            });
+    };
+}
+
+export function startDownload() {
+    return dispatch => {
+        dispatch(startDownloadAction());
+
+        autoUpdater.on('download-progress', progressObj => {
+            dispatch(updateDownloadingAction(progressObj.percent));
+        });
+        autoUpdater.on('update-downloaded', () => {
+            autoUpdater.removeAllListeners();
+            autoUpdater.quitAndInstall();
+        });
+        autoUpdater.on('error', error => {
+            autoUpdater.removeAllListeners();
+            if (error.message === 'Cancelled') {
+                dispatch(downloadCancelledAction());
+            } else {
+                dispatch(updateErrorAction(error));
+                dispatch(ErrorDialogActions.showDialog(error.message));
+            }
+        });
+
+        autoUpdater.downloadUpdate(cancellationToken);
+    };
+}
+
+export function cancelDownload() {
+    return dispatch => {
+        dispatch(cancelDownloadAction());
+        cancellationToken.cancel();
+    };
+}

--- a/lib/windows/launcher/components/UpdateAvailableDialog.jsx
+++ b/lib/windows/launcher/components/UpdateAvailableDialog.jsx
@@ -1,0 +1,66 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React, { PropTypes } from 'react';
+
+import ConfirmationDialog from '../../../components/ConfirmationDialog';
+
+const UpdateAvailableDialog = ({
+    isVisible,
+    version,
+    onConfirm,
+    onCancel,
+}) => (
+    <ConfirmationDialog
+        isVisible={isVisible}
+        title="Update available"
+        text={`A new version (${version}) of nRF Connect is available. ` +
+            'Would you like to upgrade now?'}
+        okButtonText="Yes"
+        cancelButtonText="No"
+        onOk={() => onConfirm()}
+        onCancel={() => onCancel()}
+    />
+);
+
+UpdateAvailableDialog.propTypes = {
+    isVisible: PropTypes.bool.isRequired,
+    version: PropTypes.string.isRequired,
+    onConfirm: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+};
+
+export default UpdateAvailableDialog;

--- a/lib/windows/launcher/components/UpdateProgressDialog.jsx
+++ b/lib/windows/launcher/components/UpdateProgressDialog.jsx
@@ -1,0 +1,88 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React, { PropTypes } from 'react';
+import { Modal, Button, ModalHeader, ModalFooter, ModalBody, ModalTitle, ProgressBar } from 'react-bootstrap';
+import Spinner from '../../../components/Spinner';
+
+const UpdateProgressDialog = ({
+    isVisible,
+    isProgressSupported,
+    isCancelSupported,
+    version,
+    percentDownloaded,
+    onCancel,
+    isCancelling,
+}) => (
+    <Modal show={isVisible} backdrop>
+        <ModalHeader closeButton={false}>
+            <ModalTitle>Downloading update</ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+            <p>Downloading nRF Connect {version}...</p>
+            {
+                isProgressSupported &&
+                    <ProgressBar label={`${percentDownloaded}%`} now={percentDownloaded} />
+            }
+            <p>
+                This might take a few minutes. The application will restart and update
+                once the download is complete.
+            </p>
+        </ModalBody>
+        <ModalFooter>
+            {
+                !isProgressSupported &&
+                    <Spinner />
+            }
+            {
+                isCancelSupported &&
+                    <Button onClick={onCancel} disabled={isCancelling}>Cancel</Button>
+            }
+        </ModalFooter>
+    </Modal>
+);
+
+UpdateProgressDialog.propTypes = {
+    isVisible: PropTypes.bool.isRequired,
+    isProgressSupported: PropTypes.bool.isRequired,
+    isCancelSupported: PropTypes.bool.isRequired,
+    version: PropTypes.string.isRequired,
+    percentDownloaded: PropTypes.number.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    isCancelling: PropTypes.bool.isRequired,
+};
+
+export default UpdateProgressDialog;

--- a/lib/windows/launcher/components/__tests__/UpdateProgressDialog-test.jsx
+++ b/lib/windows/launcher/components/__tests__/UpdateProgressDialog-test.jsx
@@ -1,0 +1,110 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* eslint-disable import/first */
+
+// Do not render react-bootstrap components in tests
+jest.mock('react-bootstrap', () => ({
+    Modal: 'Modal',
+    Button: 'Button',
+    ModalHeader: 'ModalHeader',
+    ModalFooter: 'ModalFooter',
+    ModalBody: 'ModalBody',
+    ModalTitle: 'ModalTitle',
+    ProgressBar: 'ProgressBar',
+}));
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import UpdateProgressDialog from '../UpdateProgressDialog';
+
+describe('UpdateProgressDialog', () => {
+    it('should render invisible', () => {
+        expect(renderer.create(
+            <UpdateProgressDialog
+                isVisible={false}
+                isProgressSupported={false}
+                isCancelSupported={false}
+                version=""
+                percentDownloaded={0}
+                onCancel={() => {}}
+                isCancelling={false}
+            />,
+        )).toMatchSnapshot();
+    });
+
+    it('should render with version, percent downloaded, and cancellable', () => {
+        expect(renderer.create(
+            <UpdateProgressDialog
+                isVisible
+                isProgressSupported
+                isCancelSupported
+                version="1.2.3"
+                percentDownloaded={42}
+                onCancel={() => {}}
+                isCancelling={false}
+            />,
+        )).toMatchSnapshot();
+    });
+
+    it('should render with version, without progress, and not cancellable', () => {
+        expect(renderer.create(
+            <UpdateProgressDialog
+                isVisible
+                isProgressSupported={false}
+                isCancelSupported={false}
+                version="1.2.3"
+                percentDownloaded={0}
+                onCancel={() => {}}
+                isCancelling={false}
+            />,
+        )).toMatchSnapshot();
+    });
+
+    it('should render cancelling', () => {
+        expect(renderer.create(
+            <UpdateProgressDialog
+                isVisible
+                isProgressSupported
+                isCancelSupported
+                version="1.2.3"
+                percentDownloaded={42}
+                onCancel={() => {}}
+                isCancelling
+            />,
+        )).toMatchSnapshot();
+    });
+});

--- a/lib/windows/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
@@ -1,0 +1,127 @@
+exports[`UpdateProgressDialog should render cancelling 1`] = `
+<Modal
+  backdrop={true}
+  show={true}>
+  <ModalHeader
+    closeButton={false}>
+    <ModalTitle>
+      Downloading update
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Downloading nRF Connect 
+      1.2.3
+      ...
+    </p>
+    <ProgressBar
+      label="42%"
+      now={42} />
+    <p>
+      This might take a few minutes. The application will restart and update once the download is complete.
+    </p>
+  </ModalBody>
+  <ModalFooter>
+    <Button
+      disabled={true}
+      onClick={[Function]}>
+      Cancel
+    </Button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`UpdateProgressDialog should render invisible 1`] = `
+<Modal
+  backdrop={true}
+  show={false}>
+  <ModalHeader
+    closeButton={false}>
+    <ModalTitle>
+      Downloading update
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Downloading nRF Connect 
+      
+      ...
+    </p>
+    <p>
+      This might take a few minutes. The application will restart and update once the download is complete.
+    </p>
+  </ModalBody>
+  <ModalFooter>
+    <img
+      alt="Loading..."
+      className="core-spinner"
+      height={16}
+      src="test-file-stub"
+      width={16} />
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`UpdateProgressDialog should render with version, percent downloaded, and cancellable 1`] = `
+<Modal
+  backdrop={true}
+  show={true}>
+  <ModalHeader
+    closeButton={false}>
+    <ModalTitle>
+      Downloading update
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Downloading nRF Connect 
+      1.2.3
+      ...
+    </p>
+    <ProgressBar
+      label="42%"
+      now={42} />
+    <p>
+      This might take a few minutes. The application will restart and update once the download is complete.
+    </p>
+  </ModalBody>
+  <ModalFooter>
+    <Button
+      disabled={false}
+      onClick={[Function]}>
+      Cancel
+    </Button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`UpdateProgressDialog should render with version, without progress, and not cancellable 1`] = `
+<Modal
+  backdrop={true}
+  show={true}>
+  <ModalHeader
+    closeButton={false}>
+    <ModalTitle>
+      Downloading update
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Downloading nRF Connect 
+      1.2.3
+      ...
+    </p>
+    <p>
+      This might take a few minutes. The application will restart and update once the download is complete.
+    </p>
+  </ModalBody>
+  <ModalFooter>
+    <img
+      alt="Loading..."
+      className="core-spinner"
+      height={16}
+      src="test-file-stub"
+      width={16} />
+  </ModalFooter>
+</Modal>
+`;

--- a/lib/windows/launcher/containers/UpdateAvailableContainer.js
+++ b/lib/windows/launcher/containers/UpdateAvailableContainer.js
@@ -34,25 +34,27 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React from 'react';
-import NavMenuContainer from '../containers/NavMenuContainer';
-import MainViewContainer from '../containers/MainViewContainer';
-import ErrorDialogContainer from '../containers/ErrorDialogContainer';
-import UpdateAvailableContainer from '../containers/UpdateAvailableContainer';
-import UpdateProgressContainer from '../containers/UpdateProgressContainer';
-import Logo from '../../../components/Logo';
+import { connect } from 'react-redux';
+import UpdateAvailableDialog from '../components/UpdateAvailableDialog';
+import * as AutoUpdateActions from '../actions/autoUpdateActions';
 
-export default () => (
-    <div className="core-main-area">
-        <div className="core-nav-bar">
-            <NavMenuContainer />
-            <Logo />
-        </div>
-        <div className="core-main-layout">
-            <MainViewContainer />
-        </div>
-        <ErrorDialogContainer />
-        <UpdateAvailableContainer />
-        <UpdateProgressContainer />
-    </div>
-);
+function mapStateToProps(state) {
+    const { autoUpdate } = state;
+
+    return {
+        isVisible: autoUpdate.isUpdateAvailableDialogVisible,
+        version: autoUpdate.latestVersion,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        onConfirm: () => dispatch(AutoUpdateActions.startDownload()),
+        onCancel: () => dispatch(AutoUpdateActions.postponeUpdate()),
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(UpdateAvailableDialog);

--- a/lib/windows/launcher/containers/UpdateProgressContainer.js
+++ b/lib/windows/launcher/containers/UpdateProgressContainer.js
@@ -34,25 +34,30 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React from 'react';
-import NavMenuContainer from '../containers/NavMenuContainer';
-import MainViewContainer from '../containers/MainViewContainer';
-import ErrorDialogContainer from '../containers/ErrorDialogContainer';
-import UpdateAvailableContainer from '../containers/UpdateAvailableContainer';
-import UpdateProgressContainer from '../containers/UpdateProgressContainer';
-import Logo from '../../../components/Logo';
+import { connect } from 'react-redux';
+import UpdateProgressDialog from '../components/UpdateProgressDialog';
+import * as AutoUpdateActions from '../actions/autoUpdateActions';
 
-export default () => (
-    <div className="core-main-area">
-        <div className="core-nav-bar">
-            <NavMenuContainer />
-            <Logo />
-        </div>
-        <div className="core-main-layout">
-            <MainViewContainer />
-        </div>
-        <ErrorDialogContainer />
-        <UpdateAvailableContainer />
-        <UpdateProgressContainer />
-    </div>
-);
+function mapStateToProps(state) {
+    const { autoUpdate } = state;
+
+    return {
+        isVisible: autoUpdate.isUpdateProgressDialogVisible,
+        isProgressSupported: autoUpdate.isProgressSupported,
+        isCancelSupported: autoUpdate.isCancelSupported,
+        version: autoUpdate.latestVersion,
+        percentDownloaded: autoUpdate.percentDownloaded,
+        isCancelling: autoUpdate.isCancelling,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        onCancel: () => dispatch(AutoUpdateActions.cancelDownload()),
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(UpdateProgressDialog);

--- a/lib/windows/launcher/index.js
+++ b/lib/windows/launcher/index.js
@@ -38,11 +38,21 @@ import 'babel-polyfill';
 
 import React from 'react';
 import { render } from 'react-dom';
+import { remote } from 'electron';
+import isDev from 'electron-is-dev';
 import RootContainer from './containers/RootContainer';
 import configureStore from '../../store/configureStore';
 import rootReducer from './reducers';
+import * as AutoUpdateActions from './actions/autoUpdateActions';
 import '../../../resources/css/launcher.less';
+
+const config = remote.require('./main/config');
 
 const store = configureStore(rootReducer);
 const rootElement = React.createElement(RootContainer, { store });
-render(rootElement, document.getElementById('webapp'));
+
+render(rootElement, document.getElementById('webapp'), () => {
+    if (!isDev && !config.isSkipUpdateCore()) {
+        store.dispatch(AutoUpdateActions.checkForUpdates());
+    }
+});

--- a/lib/windows/launcher/reducers/__tests__/autoUpdateReducer-test.js
+++ b/lib/windows/launcher/reducers/__tests__/autoUpdateReducer-test.js
@@ -1,0 +1,165 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* eslint-disable import/first */
+
+jest.mock('electron', () => ({
+    remote: {
+        require: () => ({
+            autoUpdater: {},
+            CancellationToken: class CancellationToken {},
+        }),
+    },
+}));
+
+import * as AutoUpdateActions from '../../actions/autoUpdateActions';
+import reducer from '../autoUpdateReducer';
+
+const initialState = reducer(undefined, {});
+
+describe('autoUpdateReducer', () => {
+    it('should not show any dialogs in initial state', () => {
+        expect(initialState.isUpdateAvailableDialogVisible).toEqual(false);
+        expect(initialState.isUpdateProgressDialogVisible).toEqual(false);
+    });
+
+    it('should have zero download percentage in initial state', () => {
+        expect(initialState.percentDownloaded).toEqual(0);
+    });
+
+    it('should show the update available dialog when AUTO_UPDATE_AVAILABLE has been dispatched', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_AVAILABLE,
+        });
+        expect(state.isUpdateAvailableDialogVisible).toEqual(true);
+    });
+
+    it('should know latest version when AUTO_UPDATE_AVAILABLE has been dispatched with version', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_AVAILABLE,
+            version: '1.2.3',
+        });
+        expect(state.latestVersion).toEqual('1.2.3');
+    });
+
+    it('should hide the update available dialog when AUTO_UPDATE_POSTPONE has been dispatched', () => {
+        const firstState = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_AVAILABLE,
+        });
+        const secondState = reducer(firstState, {
+            type: AutoUpdateActions.AUTO_UPDATE_POSTPONE,
+        });
+        expect(secondState.isUpdateAvailableDialogVisible).toEqual(false);
+    });
+
+    it('should hide the update available dialog when AUTO_UPDATE_START_DOWNLOAD has been dispatched', () => {
+        const firstState = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_AVAILABLE,
+        });
+        const secondState = reducer(firstState, {
+            type: AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD,
+        });
+        expect(secondState.isUpdateAvailableDialogVisible).toEqual(false);
+    });
+
+    it('should show the progress dialog when AUTO_UPDATE_START_DOWNLOAD has been dispatched', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD,
+        });
+        expect(state.isUpdateProgressDialogVisible).toEqual(true);
+    });
+
+    it('should not have progress/cancel support when AUTO_UPDATE_START_DOWNLOAD has been dispatched without it', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD,
+        });
+        expect(state.isProgressSupported).toEqual(false);
+        expect(state.isCancelSupported).toEqual(false);
+    });
+
+    it('should set progress support when AUTO_UPDATE_START_DOWNLOAD has been dispatched with progress support', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD,
+            isProgressSupported: true,
+        });
+        expect(state.isProgressSupported).toEqual(true);
+    });
+
+    it('should set cancel support when AUTO_UPDATE_START_DOWNLOAD has been dispatched with cancel support', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD,
+            isCancelSupported: true,
+        });
+        expect(state.isCancelSupported).toEqual(true);
+    });
+
+    it('should update download percentage when AUTO_UPDATE_DOWNLOADING has been dispatched with percent', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_DOWNLOADING,
+            percentDownloaded: 42,
+        });
+        expect(state.percentDownloaded).toEqual(42);
+    });
+
+    it('should round download percentage down to nearest integer', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_DOWNLOADING,
+            percentDownloaded: 42.9,
+        });
+        expect(state.percentDownloaded).toEqual(42);
+    });
+
+    it('should set isCancelling when AUTO_UPDATE_CANCEL_DOWNLOAD has been dispatched', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_CANCEL_DOWNLOAD,
+        });
+        expect(state.isCancelling).toEqual(true);
+    });
+
+    it('should return initial state when AUTO_UPDATE_DOWNLOAD_CANCELLED has been dispatched', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_DOWNLOAD_CANCELLED,
+        });
+        expect(state).toEqual(initialState);
+    });
+
+    it('should return initial state when AUTO_UPDATE_ERROR has been dispatched', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_ERROR,
+        });
+        expect(state).toEqual(initialState);
+    });
+});

--- a/lib/windows/launcher/reducers/autoUpdateReducer.js
+++ b/lib/windows/launcher/reducers/autoUpdateReducer.js
@@ -1,0 +1,90 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { Record } from 'immutable';
+import * as AutoUpdateActions from '../actions/autoUpdateActions';
+
+const InitialState = Record({
+    isUpdateAvailableDialogVisible: false,
+    isUpdateProgressDialogVisible: false,
+    isProgressSupported: false,
+    isCancelSupported: false,
+    latestVersion: '',
+    percentDownloaded: 0,
+    isCancelling: false,
+});
+const initialState = new InitialState();
+
+function setUpdateAvailable(state, version) {
+    return state
+        .set('latestVersion', version)
+        .set('isUpdateAvailableDialogVisible', true);
+}
+
+function setDownloading(state, action) {
+    return state
+        .set('isUpdateAvailableDialogVisible', false)
+        .set('isUpdateProgressDialogVisible', true)
+        .set('isProgressSupported', !!action.isProgressSupported)
+        .set('isCancelSupported', !!action.isCancelSupported);
+}
+
+function setPercentDownloadedAsInteger(state, percentDownloaded) {
+    return state.set('percentDownloaded', parseInt(percentDownloaded, 10));
+}
+
+const reducer = (state = initialState, action) => {
+    switch (action.type) {
+        case AutoUpdateActions.AUTO_UPDATE_AVAILABLE:
+            return setUpdateAvailable(state, action.version);
+        case AutoUpdateActions.AUTO_UPDATE_POSTPONE:
+            return state.set('isUpdateAvailableDialogVisible', false);
+        case AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD:
+            return setDownloading(state, action);
+        case AutoUpdateActions.AUTO_UPDATE_DOWNLOADING:
+            return setPercentDownloadedAsInteger(state, action.percentDownloaded);
+        case AutoUpdateActions.AUTO_UPDATE_CANCEL_DOWNLOAD:
+            return state.set('isCancelling', true);
+        case AutoUpdateActions.AUTO_UPDATE_DOWNLOAD_CANCELLED:
+            return initialState;
+        case AutoUpdateActions.AUTO_UPDATE_ERROR:
+            return initialState;
+        default:
+            return state;
+    }
+};
+
+export default reducer;

--- a/lib/windows/launcher/reducers/index.js
+++ b/lib/windows/launcher/reducers/index.js
@@ -37,10 +37,12 @@
 import { combineReducers } from 'redux';
 import navMenu from './navMenuReducer';
 import apps from './appsReducer';
+import autoUpdate from './autoUpdateReducer';
 import errorDialog from '../../../reducers/errorDialogReducer';
 
 export default combineReducers({
     navMenu,
     apps,
+    autoUpdate,
     errorDialog,
 });

--- a/main/autoUpdate.js
+++ b/main/autoUpdate.js
@@ -1,0 +1,48 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const autoUpdater = require('electron-updater').autoUpdater;
+const CancellationToken = require('electron-builder-http/out/CancellationToken').CancellationToken;
+const log = require('electron-log');
+
+autoUpdater.autoDownload = false;
+autoUpdater.logger = log;
+autoUpdater.logger.transports.file.level = 'info';
+
+module.exports.autoUpdater = autoUpdater;
+module.exports.CancellationToken = CancellationToken;

--- a/main/config.js
+++ b/main/config.js
@@ -38,7 +38,9 @@
 
 const electronApp = require('electron').app;
 const path = require('path');
+const packageJson = require('../package.json');
 
+let version;
 let homeDir;
 let userDataDir;
 let appsRootDir;
@@ -52,6 +54,7 @@ let appsJsonUrl;
 let skipUpdateApps;
 
 function init(argv) {
+    version = packageJson.version;
     homeDir = electronApp.getPath('home');
     userDataDir = electronApp.getPath('userData');
     appsRootDir = argv['apps-root-dir'] || path.join(homeDir, '.nrfconnect-apps');
@@ -67,6 +70,7 @@ function init(argv) {
 
 module.exports = {
     init,
+    getVersion: () => version,
     getHomeDir: () => homeDir,
     getUserDataDir: () => userDataDir,
     getAppsRootDir: () => appsRootDir,

--- a/main/config.js
+++ b/main/config.js
@@ -52,6 +52,7 @@ let updatesJsonPath;
 let appsJsonPath;
 let appsJsonUrl;
 let skipUpdateApps;
+let skipUpdateCore;
 
 function init(argv) {
     version = packageJson.version;
@@ -66,6 +67,7 @@ function init(argv) {
     appsJsonPath = path.join(appsRootDir, 'apps.json');
     appsJsonUrl = 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfconnect-core/master/apps.json';
     skipUpdateApps = argv['skip-update-apps'] || false;
+    skipUpdateCore = argv['skip-update-core'] || false;
 }
 
 module.exports = {
@@ -82,4 +84,5 @@ module.exports = {
     getAppsJsonPath: () => appsJsonPath,
     getAppsJsonUrl: () => appsJsonUrl,
     isSkipUpdateApps: () => skipUpdateApps,
+    isSkipUpdateCore: () => skipUpdateCore,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.0.0-pre0",
+    "version": "2.0.0-alpha.0",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,17 @@
         "clean-dist": "rimraf dist",
         "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\"",
         "get-nrfjprog": "node build/get-nrfjprog.js",
-        "pack": "npm run build && build -p never"
+        "pack": "npm run build && build -p never",
+        "release": "build -p always"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "Proprietary",
     "build": {
         "appId": "com.nordicsemi.nrfconnect",
         "productName": "nRF Connect",
+        "publish": [
+            "github"
+        ],
         "files": [
             "dist/",
             "main/",
@@ -60,16 +64,13 @@
             ]
         },
         "nsis": {
-            "oneClick": false,
-            "allowToChangeInstallationDirectory": true,
-            "runAfterFinish": false,
             "menuCategory": "Nordic Semiconductor",
             "include": "build/installer.nsh"
         }
     },
     "devDependencies": {
         "asar": "0.13.0",
-        "electron-builder": "17.0.3",
+        "electron-builder": "17.3.1",
         "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git",
         "electron": "1.4.13",
         "spectron": "3.6.0",
@@ -80,6 +81,10 @@
     "dependencies": {
         "babel-polyfill": "6.22.0",
         "bootstrap": "3.3.7",
+        "electron-builder-http": "17.4.0",
+        "electron-is-dev": "0.1.2",
+        "electron-log": "2.2.4",
+        "electron-updater": "1.14.3",
         "immutable": "3.8.1",
         "moment": "2.17.1",
         "mousetrap": "1.6.0",

--- a/test/oneLocalApp-test.js
+++ b/test/oneLocalApp-test.js
@@ -40,7 +40,6 @@ import packageJson from '../package.json';
 
 const appsRootDir = path.resolve(__dirname, './features/one-local-app');
 const electronArgs = [
-    '--skip-update-apps',
     `--apps-root-dir=${appsRootDir}`,
 ];
 

--- a/test/oneOfficialAppInstalled-test.js
+++ b/test/oneOfficialAppInstalled-test.js
@@ -39,7 +39,6 @@ import { startElectronApp, stopElectronApp } from './setup';
 
 const appsRootDir = path.resolve(__dirname, './features/one-official-app-installed');
 const electronArgs = [
-    '--skip-update-apps',
     `--apps-root-dir=${appsRootDir}`,
 ];
 

--- a/test/oneOfficialAppNotInstalled-test.js
+++ b/test/oneOfficialAppNotInstalled-test.js
@@ -39,7 +39,6 @@ import { startElectronApp, stopElectronApp } from './setup';
 
 const appsRootDir = path.resolve(__dirname, './features/one-official-app-not-installed');
 const electronArgs = [
-    '--skip-update-apps',
     `--apps-root-dir=${appsRootDir}`,
 ];
 

--- a/test/oneOfficialAppUpgradable-test.js
+++ b/test/oneOfficialAppUpgradable-test.js
@@ -39,7 +39,6 @@ import { startElectronApp, stopElectronApp } from './setup';
 
 const appsRootDir = path.resolve(__dirname, './features/one-official-app-upgradable');
 const electronArgs = [
-    '--skip-update-apps',
     `--apps-root-dir=${appsRootDir}`,
 ];
 

--- a/test/setup/index.js
+++ b/test/setup/index.js
@@ -50,6 +50,8 @@ if (process.platform === 'win32') {
 function startElectronApp(extraArgs) {
     const args = [
         projectPath,
+        '--skip-update-apps',
+        '--skip-update-core',
     ];
     const electronApp = new Application({
         path: electronPath,


### PR DESCRIPTION
At startup, nRF Connect will now check for new releases on GitHub. If a new release is available, this will pop up in the launcher window:

![image](https://cloud.githubusercontent.com/assets/461755/25957013/9820921e-366d-11e7-87af-e4aa04595d05.png)

When clicking "Yes", it will start downloading the new version:

![image](https://cloud.githubusercontent.com/assets/461755/25957157/f202ab46-366d-11e7-8ab7-a5f901bd4351.png)

I had to make some adjustments for macOS, as download progress and cancel is not supported there:

![image](https://cloud.githubusercontent.com/assets/461755/25957311/4c0ac8ee-366e-11e7-983d-f06a2b90405c.png)

When the download is complete, nRF Connect exits, the new version is installed, and nRF Connect is started again.