### PR TITLE
Mock serialport and logger in serialPortReducer-test.js

### DIFF
--- a/lib/windows/app/reducers/__tests__/serialPortReducer-test.js
+++ b/lib/windows/app/reducers/__tests__/serialPortReducer-test.js
@@ -34,6 +34,11 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* eslint-disable import/first */
+
+jest.mock('serialport', () => {});
+jest.mock('../../../../api/logging', () => {});
+
 import reducer from '../serialPortReducer';
 import * as SerialPortActions from '../../actions/serialPortActions';
 


### PR DESCRIPTION
The build started failing after merging #64 to master. This PR fixes the issue.

The logger and serialport are not dependency injected into action creators anymore, but imported directly. This means that we have to mock them in unit tests. This is because they depend on things like Node.js addons and electron, which is not available during unit testing.