### PR TITLE
Revert to tar v2.2.1 due to cmake-js incompatibility

### DIFF
--- a/build/get-nrfjprog.js
+++ b/build/get-nrfjprog.js
@@ -122,7 +122,7 @@ function downloadFile(url, destinationFile) {
 
 function extractTarFile(filePath, outputDir) {
     return new Promise((resolve, reject) => {
-        const extractor = tar.extract({ path: outputDir })
+        const extractor = tar.Extract({ path: outputDir })
             .on('error', err => reject(err))
             .on('end', () => resolve());
         fs.createReadStream(filePath)

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git",
         "electron": "1.6.7",
         "spectron": "3.7.0",
-        "tar": "3.1.3",
+        "tar": "2.2.1",
         "util": "0.10.3",
         "xvfb-maybe": "0.2.1"
     },


### PR DESCRIPTION
Building pc-ble-driver-js fails on build servers after upgrading tar from v2 to v3. Reverting to v2 to avoid the issue.