### PR TITLE
Fix spectron version incompatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function openLauncherWindow() {
         width: 670,
         height: 500,
         center: true,
-        splashScreen: true,
+        splashScreen: !config.isSkipSplashScreen(),
     });
 
     launcherWindow.on('close', event => {

--- a/main/config.js
+++ b/main/config.js
@@ -53,6 +53,7 @@ let appsJsonPath;
 let appsJsonUrl;
 let skipUpdateApps;
 let skipUpdateCore;
+let skipSplashScreen;
 
 function init(argv) {
     version = packageJson.version;
@@ -68,6 +69,7 @@ function init(argv) {
     appsJsonUrl = 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfconnect-core/master/apps.json';
     skipUpdateApps = argv['skip-update-apps'] || false;
     skipUpdateCore = argv['skip-update-core'] || false;
+    skipSplashScreen = argv['skip-splash-screen'] || false;
 }
 
 module.exports = {
@@ -85,4 +87,5 @@ module.exports = {
     getAppsJsonUrl: () => appsJsonUrl,
     isSkipUpdateApps: () => skipUpdateApps,
     isSkipUpdateCore: () => skipUpdateCore,
+    isSkipSplashScreen: () => skipSplashScreen,
 };

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "electron-builder": "17.8.0",
         "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git",
         "electron": "1.6.7",
-        "spectron": "3.7.0",
+        "spectron": "3.6.4",
         "tar": "2.2.1",
         "util": "0.10.3",
         "xvfb-maybe": "0.2.1"

--- a/test/oneLocalApp-test.js
+++ b/test/oneLocalApp-test.js
@@ -46,7 +46,7 @@ const electronArgs = [
 let electronApp;
 
 function loadFirstApp() {
-    return electronApp.client.windowByIndex(1)
+    return electronApp.client.windowByIndex(0)
         .click('button[title="Launch app"]')
         .then(() => electronApp.client.waitUntilWindowLoaded());
 }
@@ -63,23 +63,13 @@ describe('one local app', () => {
         stopElectronApp(electronApp)
     ));
 
-    it('should open two windows when electron is started', () => (
-        electronApp.client.getWindowCount()
-            .then(windowCount => expect(windowCount).toEqual(2))
-    ));
-
-    it('should display splash screen image in first window when electron is started', () => (
-        electronApp.client.windowByIndex(0).isVisible('div[style*=\'splashscreen.png\']')
-            .then(isSplashVisible => expect(isSplashVisible).toEqual(true))
-    ));
-
     it('should show package.json version in launcher window title', () => (
-        electronApp.client.windowByIndex(1).browserWindow.getTitle()
+        electronApp.client.windowByIndex(0).browserWindow.getTitle()
             .then(title => expect(title).toContain(packageJson.version))
     ));
 
     it('should show Test App in the launcher app list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .getText('h4')
             .then(text => expect(text).toEqual('Test App'))
     ));

--- a/test/oneOfficialAppInstalled-test.js
+++ b/test/oneOfficialAppInstalled-test.js
@@ -45,7 +45,7 @@ const electronArgs = [
 let electronApp;
 
 function loadFirstApp() {
-    return electronApp.client.windowByIndex(1)
+    return electronApp.client.windowByIndex(0)
         .click('button[title="Launch app"]')
         .then(() => electronApp.client.waitUntilWindowLoaded());
 }
@@ -63,7 +63,7 @@ describe('one official app installed', () => {
     ));
 
     it('should show Test App in the launcher app list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .getText('h4')
             .then(text => expect(text).toEqual('Test App'))
     ));
@@ -82,7 +82,7 @@ describe('one official app installed', () => {
     ));
 
     it('should show Test App in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .getText('h4')
@@ -90,7 +90,7 @@ describe('one official app installed', () => {
     ));
 
     it('should show remove button for Test App in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .isVisible('button[title="Remove Test App"]')
@@ -98,7 +98,7 @@ describe('one official app installed', () => {
     ));
 
     it('should not show install button in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .isVisible('button[title="Install Test App"]')
@@ -106,7 +106,7 @@ describe('one official app installed', () => {
     ));
 
     it('should not show upgrade button in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .isVisible('button[title*="Upgrade"]')

--- a/test/oneOfficialAppNotInstalled-test.js
+++ b/test/oneOfficialAppNotInstalled-test.js
@@ -57,13 +57,13 @@ describe('one official app not installed', () => {
     ));
 
     it('should show welcome message in the launcher app list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .getText('h4')
             .then(text => expect(text).toEqual('Welcome to nRF Connect'))
     ));
 
     it('should show Test App in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .getText('h4')
@@ -71,7 +71,7 @@ describe('one official app not installed', () => {
     ));
 
     it('should show install button for Test App in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .isVisible('button[title="Install Test App"]')
@@ -79,7 +79,7 @@ describe('one official app not installed', () => {
     ));
 
     it('should not show remove button in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .isVisible('button[title*="Remove"]')
@@ -87,7 +87,7 @@ describe('one official app not installed', () => {
     ));
 
     it('should not show upgrade button in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .isVisible('button[title*="Upgrade"]')

--- a/test/oneOfficialAppUpgradable-test.js
+++ b/test/oneOfficialAppUpgradable-test.js
@@ -57,13 +57,13 @@ describe('one official app upgradable', () => {
     ));
 
     it('should show Test App in the launcher app list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .getText('h4')
             .then(text => expect(text).toEqual('Test App'))
     ));
 
     it('should show Test App in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .getText('h4')
@@ -71,7 +71,7 @@ describe('one official app upgradable', () => {
     ));
 
     it('should show remove button for Test App in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .isVisible('button[title="Remove Test App"]')
@@ -79,7 +79,7 @@ describe('one official app upgradable', () => {
     ));
 
     it('should show upgrade button in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .isVisible('button[title="Upgrade Test App from v1.2.3 to v1.2.4"]')
@@ -87,7 +87,7 @@ describe('one official app upgradable', () => {
     ));
 
     it('should not show install button in app management list', () => (
-        electronApp.client.windowByIndex(1)
+        electronApp.client.windowByIndex(0)
             .click('button[title*="Add/remove apps"]')
             .isVisible('core-app-management-item')
             .isVisible('button[title="Install Test App"]')

--- a/test/setup/index.js
+++ b/test/setup/index.js
@@ -52,6 +52,7 @@ function startElectronApp(extraArgs) {
         projectPath,
         '--skip-update-apps',
         '--skip-update-core',
+        '--skip-splash-screen',
     ];
     const electronApp = new Application({
         path: electronPath,


### PR DESCRIPTION
The minor version of spectron has to match the minor version of electron. This is because spectron comes with electron-chromedriver, which must be compatible with the electron version we are using. More info: https://www.npmjs.com/package/spectron.

Also skipping the splash screen in integration tests now. It seems to cause some random "window not available" errors when calling `windowByIndex()`.