### PR TITLE
Bundle as much as we can with webpack to reduce loading time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.0.0-alpha.2",
+    "version": "2.0.0-alpha.3",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,18 +1,20 @@
 const webpack = require('webpack');
 const path = require('path');
-const dependencies = require('./package.json').dependencies;
 
 const nodeEnv = process.env.NODE_ENV || 'development';
 const isProd = nodeEnv === 'production';
 
 function createExternals() {
-    // Add production dependencies as externals, but keep the require behavior.
-    // http://jlongster.com/Backend-Apps-with-Webpack--Part-I
-    const externals = {};
-    Object.keys(dependencies).forEach(dependency => {
-        externals[dependency] = `commonjs ${dependency}`;
-    });
-    return externals;
+    // Some libraries, e.g. those with native addons, cannot be bundled
+    // by webpack. Adding them as externals so that they are not bundled.
+    const libs = [
+        'pc-ble-driver-js',
+        'pc-nrfjprog-js',
+        'serialport',
+    ];
+    return libs.reduce((prev, lib) => (
+        Object.assign(prev, { [lib]: `commonjs ${lib}` })
+    ), {});
 }
 
 module.exports = {


### PR DESCRIPTION
Up until now, we have added all dependencies as externals. This is convenient as we do not have to manually specify which libs should be external. However, it comes with a performance penalty.

When opening the browser window, all require's of the web page are processed. If the application needs to load required modules from node_modules, then it first needs to figure out where the module exists on the file system, then open the files, and finally parse them.

If we bundle as much as possible into dist/ at build time, then the application can skip a lot of the resolving/opening of files at runtime. In my Windows VM this reduces the loading time of apps from ~2.2 sec to ~1.5 sec.

It does, however, cause webpack to use more time when building. We could consider only doing this for production builds if the longer building time turns out to be annoying.