### PR TITLE
Upgrade electron-builder to fix broken symlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "babel-polyfill": "6.23.0",
         "bootstrap": "3.3.7",
         "electron": "1.6.7",
-        "electron-builder": "17.8.0",
+        "electron-builder": "18.5.1",
         "electron-is-dev": "0.1.2",
         "moment": "2.18.1",
         "mousetrap": "1.6.1",
@@ -89,9 +89,9 @@
         "xvfb-maybe": "0.2.1"
     },
     "dependencies": {
-        "electron-builder-http": "17.4.0",
+        "electron-builder-http": "18.5.1",
         "electron-log": "2.2.6",
-        "electron-updater": "1.15.0",
+        "electron-updater": "2.0.0",
         "pc-ble-driver-js": "https://github.com/NordicSemiconductor/pc-ble-driver-js.git#master",
         "pc-nrfjprog-js": "https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#a742bade",
         "semver": "5.3.0",


### PR DESCRIPTION
There was a bug in electron-builder that caused symlinks to be broken in the tar.gz release artifact. We are including nrfjprog libraries with symlinks, and as a result, nrfjprog did not work. I submitted a pull request for electron-builder that fixes the issue: https://github.com/electron-userland/electron-builder/pull/1614.

Upgrading to the latest version, where the symlink fix is included.