### PR TITLE
Show download progress during auto-update on macOS

### DIFF
--- a/lib/windows/launcher/actions/autoUpdateActions.js
+++ b/lib/windows/launcher/actions/autoUpdateActions.js
@@ -67,7 +67,6 @@ function updateAvailableAction(version) {
 function startDownloadAction() {
     return {
         type: AUTO_UPDATE_START_DOWNLOAD,
-        isProgressSupported: true,
         isCancelSupported: isWindows,
     };
 }

--- a/lib/windows/launcher/actions/autoUpdateActions.js
+++ b/lib/windows/launcher/actions/autoUpdateActions.js
@@ -67,7 +67,7 @@ function updateAvailableAction(version) {
 function startDownloadAction() {
     return {
         type: AUTO_UPDATE_START_DOWNLOAD,
-        isProgressSupported: isWindows,
+        isProgressSupported: true,
         isCancelSupported: isWindows,
     };
 }

--- a/lib/windows/launcher/components/UpdateProgressDialog.jsx
+++ b/lib/windows/launcher/components/UpdateProgressDialog.jsx
@@ -37,11 +37,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button, ModalHeader, ModalFooter, ModalBody, ModalTitle, ProgressBar } from 'react-bootstrap';
-import Spinner from '../../../components/Spinner';
 
 const UpdateProgressDialog = ({
     isVisible,
-    isProgressSupported,
     isCancelSupported,
     version,
     percentDownloaded,
@@ -54,20 +52,13 @@ const UpdateProgressDialog = ({
         </ModalHeader>
         <ModalBody>
             <p>Downloading nRF Connect {version}...</p>
-            {
-                isProgressSupported &&
-                    <ProgressBar label={`${percentDownloaded}%`} now={percentDownloaded} />
-            }
+            <ProgressBar label={`${percentDownloaded}%`} now={percentDownloaded} />
             <p>
                 This might take a few minutes. The application will restart and update
                 once the download is complete.
             </p>
         </ModalBody>
         <ModalFooter>
-            {
-                !isProgressSupported &&
-                    <Spinner />
-            }
             {
                 isCancelSupported &&
                     <Button onClick={onCancel} disabled={isCancelling}>Cancel</Button>
@@ -78,7 +69,6 @@ const UpdateProgressDialog = ({
 
 UpdateProgressDialog.propTypes = {
     isVisible: PropTypes.bool.isRequired,
-    isProgressSupported: PropTypes.bool.isRequired,
     isCancelSupported: PropTypes.bool.isRequired,
     version: PropTypes.string.isRequired,
     percentDownloaded: PropTypes.number.isRequired,

--- a/lib/windows/launcher/components/__tests__/UpdateProgressDialog-test.jsx
+++ b/lib/windows/launcher/components/__tests__/UpdateProgressDialog-test.jsx
@@ -56,7 +56,6 @@ describe('UpdateProgressDialog', () => {
         expect(renderer.create(
             <UpdateProgressDialog
                 isVisible={false}
-                isProgressSupported={false}
                 isCancelSupported={false}
                 version=""
                 percentDownloaded={0}
@@ -70,7 +69,6 @@ describe('UpdateProgressDialog', () => {
         expect(renderer.create(
             <UpdateProgressDialog
                 isVisible
-                isProgressSupported
                 isCancelSupported
                 version="1.2.3"
                 percentDownloaded={42}
@@ -80,11 +78,10 @@ describe('UpdateProgressDialog', () => {
         )).toMatchSnapshot();
     });
 
-    it('should render with version, without progress, and not cancellable', () => {
+    it('should render with version and not cancellable', () => {
         expect(renderer.create(
             <UpdateProgressDialog
                 isVisible
-                isProgressSupported={false}
                 isCancelSupported={false}
                 version="1.2.3"
                 percentDownloaded={0}
@@ -98,7 +95,6 @@ describe('UpdateProgressDialog', () => {
         expect(renderer.create(
             <UpdateProgressDialog
                 isVisible
-                isProgressSupported
                 isCancelSupported
                 version="1.2.3"
                 percentDownloaded={42}

--- a/lib/windows/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
@@ -55,19 +55,45 @@ exports[`UpdateProgressDialog should render invisible 1`] = `
       
       ...
     </p>
+    <ProgressBar
+      label="0%"
+      now={0}
+    />
     <p>
       This might take a few minutes. The application will restart and update once the download is complete.
     </p>
   </ModalBody>
-  <ModalFooter>
-    <img
-      alt="Loading..."
-      className="core-spinner"
-      height={16}
-      src="test-file-stub"
-      width={16}
+  <ModalFooter />
+</Modal>
+`;
+
+exports[`UpdateProgressDialog should render with version and not cancellable 1`] = `
+<Modal
+  backdrop={true}
+  show={true}
+>
+  <ModalHeader
+    closeButton={false}
+  >
+    <ModalTitle>
+      Downloading update
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Downloading nRF Connect 
+      1.2.3
+      ...
+    </p>
+    <ProgressBar
+      label="0%"
+      now={0}
     />
-  </ModalFooter>
+    <p>
+      This might take a few minutes. The application will restart and update once the download is complete.
+    </p>
+  </ModalBody>
+  <ModalFooter />
 </Modal>
 `;
 
@@ -104,40 +130,6 @@ exports[`UpdateProgressDialog should render with version, percent downloaded, an
     >
       Cancel
     </Button>
-  </ModalFooter>
-</Modal>
-`;
-
-exports[`UpdateProgressDialog should render with version, without progress, and not cancellable 1`] = `
-<Modal
-  backdrop={true}
-  show={true}
->
-  <ModalHeader
-    closeButton={false}
-  >
-    <ModalTitle>
-      Downloading update
-    </ModalTitle>
-  </ModalHeader>
-  <ModalBody>
-    <p>
-      Downloading nRF Connect 
-      1.2.3
-      ...
-    </p>
-    <p>
-      This might take a few minutes. The application will restart and update once the download is complete.
-    </p>
-  </ModalBody>
-  <ModalFooter>
-    <img
-      alt="Loading..."
-      className="core-spinner"
-      height={16}
-      src="test-file-stub"
-      width={16}
-    />
   </ModalFooter>
 </Modal>
 `;

--- a/lib/windows/launcher/containers/UpdateProgressContainer.js
+++ b/lib/windows/launcher/containers/UpdateProgressContainer.js
@@ -43,7 +43,6 @@ function mapStateToProps(state) {
 
     return {
         isVisible: autoUpdate.isUpdateProgressDialogVisible,
-        isProgressSupported: autoUpdate.isProgressSupported,
         isCancelSupported: autoUpdate.isCancelSupported,
         version: autoUpdate.latestVersion,
         percentDownloaded: autoUpdate.percentDownloaded,

--- a/lib/windows/launcher/reducers/__tests__/autoUpdateReducer-test.js
+++ b/lib/windows/launcher/reducers/__tests__/autoUpdateReducer-test.js
@@ -102,20 +102,11 @@ describe('autoUpdateReducer', () => {
         expect(state.isUpdateProgressDialogVisible).toEqual(true);
     });
 
-    it('should not have progress/cancel support when AUTO_UPDATE_START_DOWNLOAD has been dispatched without it', () => {
+    it('should not have cancel support when AUTO_UPDATE_START_DOWNLOAD has been dispatched without it', () => {
         const state = reducer(initialState, {
             type: AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD,
         });
-        expect(state.isProgressSupported).toEqual(false);
         expect(state.isCancelSupported).toEqual(false);
-    });
-
-    it('should set progress support when AUTO_UPDATE_START_DOWNLOAD has been dispatched with progress support', () => {
-        const state = reducer(initialState, {
-            type: AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD,
-            isProgressSupported: true,
-        });
-        expect(state.isProgressSupported).toEqual(true);
     });
 
     it('should set cancel support when AUTO_UPDATE_START_DOWNLOAD has been dispatched with cancel support', () => {

--- a/lib/windows/launcher/reducers/autoUpdateReducer.js
+++ b/lib/windows/launcher/reducers/autoUpdateReducer.js
@@ -40,7 +40,6 @@ import * as AutoUpdateActions from '../actions/autoUpdateActions';
 const InitialState = Record({
     isUpdateAvailableDialogVisible: false,
     isUpdateProgressDialogVisible: false,
-    isProgressSupported: false,
     isCancelSupported: false,
     latestVersion: '',
     percentDownloaded: 0,
@@ -58,7 +57,6 @@ function setDownloading(state, action) {
     return state
         .set('isUpdateAvailableDialogVisible', false)
         .set('isUpdateProgressDialogVisible', true)
-        .set('isProgressSupported', !!action.isProgressSupported)
         .set('isCancelSupported', !!action.isCancelSupported);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.0.0-alpha.6",
+    "version": "2.0.0-alpha.7",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The latest electron-builder release adds download progress status when doing auto-update on macOS:
https://github.com/electron-userland/electron-builder/releases/tag/v18.5.1

This means that we can now show the progress bar in the UpdateProgressDialog, similar to what we are doing on Windows.