### PR TITLE
set app menu when app is ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,6 @@ global.userDataDir = config.getUserDataDir();
 global.appsRootDir = config.getAppsRootDir();
 
 const applicationMenu = Menu.buildFromTemplate(createMenu(electronApp));
-Menu.setApplicationMenu(applicationMenu);
 
 let launcherWindow;
 const appWindows = [];
@@ -121,6 +120,7 @@ function openAppWindow(app) {
 }
 
 electronApp.on('ready', () => {
+    Menu.setApplicationMenu(applicationMenu);
     apps.initAppsDirectory()
         .then(() => openLauncherWindow())
         .catch(error => {

--- a/main/menu.js
+++ b/main/menu.js
@@ -94,21 +94,6 @@ function createMenu(app) {
         },
     ];
 
-    if (process.platform === 'darwin') {
-        menuTemplate.unshift({
-            label: 'Electron',
-            submenu: [
-                {
-                    label: 'Quit',
-                    accelerator: 'Command+Q',
-                    click: () => {
-                        app.quit();
-                    },
-                },
-            ],
-        });
-    }
-
     return menuTemplate;
 }
 


### PR DESCRIPTION
Application menu only has effect when set after app is 'ready'.
Also template is simplified, on mac File menu is equivalent to 'Electron'.