### PR TITLE
Store serial numbers as integers

### DIFF
--- a/lib/windows/app/reducers/__tests__/serialPortReducer-test.js
+++ b/lib/windows/app/reducers/__tests__/serialPortReducer-test.js
@@ -107,15 +107,15 @@ describe('serialPortReducer', () => {
             comName: '/dev/tty1',
             vendorId: SEGGER_VENDOR_ID,
             manufacturer: 'SEGGER',
-            serialNumber: '680551615',
+            serialNumber: 680551615,
             productId: '0x0105',
         });
     });
 
-    it('should remove leading zeroes in serial number when adding port to state', () => {
+    it('should set serial number to -1 if it is not a number', () => {
         const seggerPort = {
             vendorId: SEGGER_VENDOR_ID,
-            serialNumber: '000680551615',
+            serialNumber: 'foobar',
         };
 
         const state = reducer(initialState, {
@@ -124,7 +124,7 @@ describe('serialPortReducer', () => {
         });
 
         const port = state.ports.first().toJS();
-        expect(port.serialNumber).toEqual('680551615');
+        expect(port.serialNumber).toEqual(-1);
     });
 
     it('should set selected port comPort when port has been selected', () => {

--- a/lib/windows/app/reducers/serialPortReducer.js
+++ b/lib/windows/app/reducers/serialPortReducer.js
@@ -57,15 +57,9 @@ function removeSeggerPrefix(serialNumber) {
     return serialNumber;
 }
 
-function removeLeadingZeroes(serialNumber) {
-    if (serialNumber) {
-        return serialNumber.replace(/\b0+/g, '');
-    }
-    return serialNumber;
-}
-
 function cleanSerialNumber(serialNumber) {
-    return removeLeadingZeroes(removeSeggerPrefix(serialNumber));
+    const number = parseInt(removeSeggerPrefix(serialNumber), 10);
+    return isNaN(number) ? -1 : number;
 }
 
 function getSeggerPorts(ports) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.0.0-alpha.7",
+    "version": "2.0.0-alpha.8",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The name `serialNumber` implies that this is a number, not a string. Also, pc-nrfjprog-js and pc-ble-driver-js expects a number when passing the serial number as a parameter.