### PR TITLE
Fix different styling for errors in log viewer

### DIFF
--- a/resources/css/app.less
+++ b/resources/css/app.less
@@ -136,7 +136,7 @@ html, body, #webapp {
         background-color: white;
     }
 
-    .core-log-error {
+    .core-log-level-error {
         color: @state-danger-text;
         background-color: @state-danger-bg;
     }


### PR DESCRIPTION
Found a bug in the style sheet. Errors had the same styling as regular log messages, but should be highlighted with red color.