### PR TITLE
Check nrfjprog version in NSIS installer

### DIFF
--- a/build/get-nrfjprog.js
+++ b/build/get-nrfjprog.js
@@ -76,6 +76,7 @@ const PLATFORM_CONFIG = {
         },
     },
     win32: {
+        // When changing this, remember to also update the nrfjprog version in installer.nsh
         url: 'https://www.nordicsemi.com/eng/nordic/download_resource/33444/40/23436026/53210',
         destinationFile: path.join(DOWNLOAD_DIR, 'nrfjprog-win32.exe'),
     },

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,4 +1,13 @@
+; Required for ${VersionCompare}
+!include "WordFunc.nsh"
+
+; Adding custom installation steps for electron-builder, ref:
+; https://github.com/electron-userland/electron-builder/wiki/NSIS
 !macro customInstall
+
+  ; The version of the bundled nRF5x-Command-Line-Tools
+  Var /GLOBAL BUNDLED_NRFJPROG_VERSION
+  StrCpy $BUNDLED_NRFJPROG_VERSION "9.4.0"
 
   ; Adding Visual C++ Redistributable for Visual Studio 2015
   File "${BUILD_RESOURCES_DIR}\vc_redist_2015.x86.exe"
@@ -6,16 +15,20 @@
   ; Running installer and waiting before continuing
   ExecWait '"$INSTDIR\vc_redist_2015.x86.exe" /passive /norestart'
 
-  ; Checking if we have nrfjprog installed, ref:
-  ; https://nsis-dev.github.io/NSIS-Forums/html/t-288318.html
-  ClearErrors
-  EnumRegKey $0 HKLM "SOFTWARE\Nordic Semiconductor\nrfjprog" 0
-  IfErrors 0 keyexist
-    ; Adding nRF5x-Command-Line-Tools installer (downloaded by 'npm run get-nrfjprog')
-    File "${BUILD_RESOURCES_DIR}\nrfjprog\nrfjprog-win32.exe"
+  ; Adding nRF5x-Command-Line-Tools installer (downloaded by 'npm run get-nrfjprog')
+  File "${BUILD_RESOURCES_DIR}\nrfjprog\nrfjprog-win32.exe"
 
-    ; Running installer and waiting before continuing
+  ; Checking if we have nRF5x-Command-Line-Tools installed
+  EnumRegKey $0 HKLM "SOFTWARE\Nordic Semiconductor\nrfjprog" 0
+  ${If} $0 == ""
+    ; nRF5x-Command-Line-Tools is not installed. Run installer.
     ExecWait '"$INSTDIR\nrfjprog-win32.exe" /passive /norestart'
-  keyexist:
+  ${Else}
+    ${VersionCompare} $BUNDLED_NRFJPROG_VERSION $0 $R0
+    ${If} $R0 == 1
+      ; nRF5x-Command-Line-Tools is older than the bundled version. Run installer.
+      ExecWait '"$INSTDIR\nrfjprog-win32.exe" /passive /norestart'
+    ${EndIf}
+  ${EndIf}
 
 !macroend

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.0.0-alpha.9",
+    "version": "2.0.0-alpha.10",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The NSIS installer only checked if nrfjprog was not installed, and ran the nrfjprog installer based on this. Now also running the nrfjprog installer if the installed version is older than the one we are bundling.