### PR TITLE
Exclude unnecessary nrfjprog files from release artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
             "dist/",
             "main/",
             "node_modules/",
+            "!node_modules/pc-nrfjprog-js/nrfjprog",
             "resources/*.html",
             "resources/*.png",
             "index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.0.0-alpha.13",
+    "version": "2.0.0-alpha.14",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The new pc-nrfjprog-js version comes with tar files and installers for nRF5x-Command-Line-Tools. When we npm install pc-nrfjprog-js, these files are included, and added to node_modules. When creating release artifacts, this adds an extra ~30 MB to the artifact size, which we do not need.

To avoid this, I am configuring electron-builder to ignore the given directory.