### PR TITLE
Revert from pc-nrfjprog-js v1.0.1 to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "electron-log": "2.2.6",
         "electron-updater": "2.0.0",
         "pc-ble-driver-js": "https://github.com/NordicSemiconductor/pc-ble-driver-js.git#v2.0.0",
-        "pc-nrfjprog-js": "https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#v1.0.1",
+        "pc-nrfjprog-js": "https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#v1.0",
         "semver": "5.3.0",
         "serialport": "4.0.7",
         "yargs": "8.0.1",


### PR DESCRIPTION
The pc-nrfjprog-js v1.0.1 does not work as expected, so rolling back to v1.0.0. The v1.0.1 waits for 500 ms before returning after performing operations, to make sure the serial port is ready. However, this does not seem to make any difference.