### PR TITLE
Set correct name for the Bluetooth low energy app

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1,7 +1,7 @@
 {
     "pc-nrfconnect-ble": {
-        "displayName": "Bluetooth Low Energy",
-        "description": "General tool for development and testing with Bluetooth Low Energy",
+        "displayName": "Bluetooth low energy",
+        "description": "General tool for development and testing with Bluetooth low energy",
         "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-ble"
     },
     "pc-nrfconnect-rssi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.0.0-alpha.15",
+    "version": "2.0.0-rc.0",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Also bumping to 2.0.0-rc.0, as we are getting close to release.