### PR TITLE
Improve app installation status in launcher

### DIFF
--- a/lib/windows/app/components/__tests__/FirmwareDialog-test.jsx
+++ b/lib/windows/app/components/__tests__/FirmwareDialog-test.jsx
@@ -60,7 +60,7 @@ describe('FirmwareDialog', () => {
                 isVisible
                 port={{
                     comName: '/dev/tty1',
-                    serialNumber: '1337',
+                    serialNumber: 1337,
                 }}
                 onCancel={() => {}}
                 onConfirmUpdateFirmware={() => {}}

--- a/lib/windows/launcher/components/AppIcon.jsx
+++ b/lib/windows/launcher/components/AppIcon.jsx
@@ -50,24 +50,39 @@ function renderAlert(altText) {
     );
 }
 
+function renderInfo(altText) {
+    return (
+        <div>
+            <span className="info-icon-bg" />
+            <span
+                className="glyphicon glyphicon-info-sign"
+                title={altText}
+            />
+        </div>
+    );
+}
+
+function renderNotice(app) {
+    if (!app.engineVersion) {
+        return renderAlert('The app does not specify which nRF Connect version(s) ' +
+            'it supports');
+    } else if (!app.isSupportedEngine) {
+        return renderAlert(`The app only supports nRF Connect ${app.engineVersion}, ` +
+            'which does not match your currently installed version');
+    } else if (app.isOfficial && app.currentVersion !== app.latestVersion) {
+        return renderInfo(`A new version (v${app.latestVersion}) of this app is ` +
+            'available, and can be installed from the "Add/remove apps" screen');
+    }
+    return null;
+}
+
 const AppIcon = ({ app }) => (
     <div className="core-app-icon">
         <img
             src={app.iconPath || nrfconnectLogo}
             alt="App icon"
         />
-        {
-            !app.engineVersion ?
-                renderAlert('The app does not specify which nRF Connect version(s) ' +
-                    'it supports')
-                : null
-        }
-        {
-            app.engineVersion && !app.isSupportedEngine ?
-                renderAlert(`The app only supports nRF Connect ${app.engineVersion}, ` +
-                    'which does not match your currently installed version')
-                : null
-        }
+        { renderNotice(app) }
     </div>
 );
 

--- a/lib/windows/launcher/components/InstalledAppItem.jsx
+++ b/lib/windows/launcher/components/InstalledAppItem.jsx
@@ -38,37 +38,43 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import AppItemButton from './AppItemButton';
 
-const InstalledAppItem = ({ app, onRemove, onUpgrade, onReadMore }) => (
-    <div className="core-app-management-item list-group-item">
-        <h4 className="list-group-item-heading">{app.displayName || app.name}</h4>
-        <div className="list-group-item-text">
-            <p>{app.description}</p>
-            <div className="core-app-management-item-footer">
-                <button className="btn btn-link core-btn-link" onClick={onReadMore}>
-                    More information
-                </button>
-                <div className="core-app-management-item-buttons">
-                    {
-                        app.latestVersion && app.currentVersion !== app.latestVersion ?
-                            <AppItemButton
-                                title={`Upgrade ${app.displayName || app.name} from v${app.currentVersion} to v${app.latestVersion}`}
-                                text="Upgrade"
-                                iconClass="glyphicon glyphicon-download-alt"
-                                onClick={onUpgrade}
-                            /> :
-                            <div />
-                    }
-                    <AppItemButton
-                        title={`Remove ${app.displayName || app.name}`}
-                        text="Remove"
-                        iconClass="glyphicon glyphicon-trash"
-                        onClick={onRemove}
-                    />
+const InstalledAppItem = ({ app, onRemove, onUpgrade, onReadMore }) => {
+    const isUpgradeAvailable = app.latestVersion && app.currentVersion !== app.latestVersion;
+    const statusClass = isUpgradeAvailable ? 'upgrade-available' : 'installed';
+    const statusText = isUpgradeAvailable ? 'Upgrade available' : 'Installed';
+    return (
+        <div className="core-app-management-item list-group-item">
+            <h4 className="list-group-item-heading">{app.displayName || app.name}</h4>
+            <div className="list-group-item-text">
+                <p>{app.description}</p>
+                <div className="core-app-management-item-footer">
+                    <button className="btn btn-link core-btn-link" onClick={onReadMore}>
+                        More information
+                    </button>
+                    <div className={`core-app-management-item-status ${statusClass}`}>{ statusText }</div>
+                    <div className="core-app-management-item-buttons">
+                        {
+                            isUpgradeAvailable ?
+                                <AppItemButton
+                                    title={`Upgrade ${app.displayName || app.name} from v${app.currentVersion} to v${app.latestVersion}`}
+                                    text="Upgrade"
+                                    iconClass="glyphicon glyphicon-download-alt"
+                                    onClick={onUpgrade}
+                                /> :
+                                <div />
+                        }
+                        <AppItemButton
+                            title={`Remove ${app.displayName || app.name}`}
+                            text="Remove"
+                            iconClass="glyphicon glyphicon-trash"
+                            onClick={onRemove}
+                        />
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-);
+    );
+};
 
 InstalledAppItem.propTypes = {
     app: PropTypes.shape({

--- a/lib/windows/launcher/components/__tests__/AppLaunchView-test.jsx
+++ b/lib/windows/launcher/components/__tests__/AppLaunchView-test.jsx
@@ -56,6 +56,7 @@ describe('AppLaunchView', () => {
     it('should render apps sorted by name and isOfficial', () => {
         const templateApp = getImmutableApp({
             currentVersion: '1.2.3',
+            latestVersion: '1.2.3',
             engineVersion: '2.x',
             isSupportedEngine: true,
         });
@@ -115,6 +116,25 @@ describe('AppLaunchView', () => {
             isOfficial: false,
             engineVersion: '1.x',
             isSupportedEngine: false,
+        });
+        expect(renderer.create(
+            <AppLaunchView
+                apps={List([app])}
+                onMount={() => {}}
+                onAppSelected={() => {}}
+            />,
+        )).toMatchSnapshot();
+    });
+
+    it('should render app with upgrade available', () => {
+        const app = getImmutableApp({
+            name: 'pc-nrfconnect-foobar',
+            currentVersion: '1.2.3',
+            latestVersion: '1.2.4',
+            path: '/path/to/pc-nrfconnect-foobar',
+            isOfficial: true,
+            engineVersion: '1.x',
+            isSupportedEngine: true,
         });
         expect(renderer.create(
             <AppLaunchView

--- a/lib/windows/launcher/components/__tests__/__snapshots__/AppLaunchView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/AppLaunchView-test.jsx.snap
@@ -120,6 +120,66 @@ exports[`AppLaunchView should render app with unsupported engine version 1`] = `
 </div>
 `;
 
+exports[`AppLaunchView should render app with upgrade available 1`] = `
+<div
+  className="list-group"
+>
+  <div
+    className="core-app-launch-item list-group-item"
+  >
+    <div
+      className="core-app-icon"
+    >
+      <img
+        alt="App icon"
+        src="test-file-stub"
+      />
+      <div>
+        <span
+          className="info-icon-bg"
+        />
+        <span
+          className="glyphicon glyphicon-info-sign"
+          title="A new version (v1.2.4) of this app is available, and can be installed from the \\"Add/remove apps\\" screen"
+        />
+      </div>
+    </div>
+    <div>
+      <h4
+        className="list-group-item-heading"
+      >
+        pc-nrfconnect-foobar
+      </h4>
+      <p
+        className="list-group-item-text"
+      >
+        official
+        , v
+        1.2.3
+      </p>
+    </div>
+    <div
+      className="core-app-launch-item-buttons"
+    >
+      <button
+        className="btn btn-primary core-btn"
+        onClick={[Function]}
+        title="Launch app"
+      >
+        <span
+          className="glyphicon glyphicon-play"
+        />
+        <span
+          className="core-btn-text"
+        >
+          Launch
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`AppLaunchView should render apps sorted by name and isOfficial 1`] = `
 <div
   className="list-group"

--- a/lib/windows/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
@@ -63,6 +63,11 @@ exports[`AppManagementView should render not-installed, installed, and upgradabl
           More information
         </button>
         <div
+          className="core-app-management-item-status upgrade-available"
+        >
+          Upgrade available
+        </div>
+        <div
           className="core-app-management-item-buttons"
         >
           <button
@@ -164,6 +169,11 @@ exports[`AppManagementView should render not-installed, installed, and upgradabl
         >
           More information
         </button>
+        <div
+          className="core-app-management-item-status installed"
+        >
+          Installed
+        </div>
         <div
           className="core-app-management-item-buttons"
         >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.0.0-rc.0",
+    "version": "2.0.0-rc.1",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",

--- a/resources/css/launcher.less
+++ b/resources/css/launcher.less
@@ -95,6 +95,24 @@ html, body, #webapp {
     .core-app-management-item-buttons > .btn {
         margin-left: 5px;
     }
+
+    .core-app-management-item-status {
+        margin-left: 10px;
+        height: 20px;
+        border-radius: 3px;
+        font-size: 10px;
+        margin-top: 7px;
+        color: white;
+        padding: 4px 10px;
+    }
+
+    .installed {
+        background-color: @brand-success;
+    }
+
+    .upgrade-available {
+        background-color: @brand-warning;
+    }
 }
 
 .core-btn-link {

--- a/resources/css/launcher.less
+++ b/resources/css/launcher.less
@@ -50,7 +50,14 @@ html, body, #webapp {
         position: absolute;
         top: 28px;
         left: 30px;
+    }
+
+    .glyphicon-alert {
         color: darkorange;
+    }
+
+    .glyphicon-info-sign {
+        color: @brand-primary-darker;
     }
 
     .alert-icon-bg {
@@ -58,6 +65,15 @@ html, body, #webapp {
         width: 8px;
         height: 12px;
         top: 32px;
+        left: 34px;
+        background-color: white;
+    }
+
+    .info-icon-bg {
+        position: absolute;
+        width: 8px;
+        height: 14px;
+        top: 30px;
         left: 34px;
         background-color: white;
     }


### PR DESCRIPTION
The launcher now shows an information icon with a tooltip text when upgrades are available.

![image](https://user-images.githubusercontent.com/461755/27683883-e9104fea-5cc7-11e7-999b-6b3fd99b4dcc.png)

Also added "Installed" and "Upgrade available" labels in the "Add/remove apps" screen to make it more obvious what the status is.

![image](https://user-images.githubusercontent.com/461755/27683964-3ee3dfd6-5cc8-11e7-912a-285e942764a3.png)
