### PR TITLE
Introduced overloadable serial port filter

### DIFF
--- a/lib/windows/app/actions/serialPortActions.js
+++ b/lib/windows/app/actions/serialPortActions.js
@@ -98,9 +98,9 @@ function getPortWithSerialNumber(port) {
 }
 
 function getPortsWithSerialNumber(ports) {
-    const promises = ports
-        .filter(port => port.vendorId === SEGGER_VENDOR_ID)
-        .map(port => getPortWithSerialNumber(port));
+    const promises = ports.map(port => (
+        port.vendorId === SEGGER_VENDOR_ID ? getPortWithSerialNumber(port) : port),
+    );
     return Promise.all(promises);
 }
 

--- a/lib/windows/app/components/SerialPortSelector.jsx
+++ b/lib/windows/app/components/SerialPortSelector.jsx
@@ -81,12 +81,12 @@ class SerialPortSelector extends React.Component {
             onSelect,
             isLoading,
             menuItemCssClass,
-            filterPort,
+            filter,
         } = this.props;
 
         if (!isLoading) {
             return ports
-                .filter(filterPort)
+                .filter(filter)
                 .map(port => (
                     <MenuItem
                         key={port.comName}
@@ -185,7 +185,7 @@ SerialPortSelector.propTypes = {
     dropdownCssClass: PropTypes.string,
     dropdownMenuCssClass: PropTypes.string,
     menuItemCssClass: PropTypes.string,
-    filterPort: PropTypes.func.isRequired,
+    filter: PropTypes.func,
 };
 
 SerialPortSelector.defaultProps = {
@@ -199,7 +199,7 @@ SerialPortSelector.defaultProps = {
     dropdownCssClass: 'core-serial-port-selector core-btn btn-primary',
     dropdownMenuCssClass: 'core-dropdown-menu',
     menuItemCssClass: 'btn-primary',
-    filterPort: filterSeggerPorts,
+    filter: filterSeggerPorts,
 };
 
 export default SerialPortSelector;

--- a/lib/windows/app/components/SerialPortSelector.jsx
+++ b/lib/windows/app/components/SerialPortSelector.jsx
@@ -42,6 +42,12 @@ import DropdownToggle from 'react-bootstrap/lib/DropdownToggle';
 import DropdownMenu from 'react-bootstrap/lib/DropdownMenu';
 import { Iterable } from 'immutable';
 
+const SEGGER_VENDOR_IDS = new Set(['0x1366', '1366']);
+
+function filterSeggerPorts(port) {
+    return SEGGER_VENDOR_IDS.has(port.vendorId);
+}
+
 class SerialPortSelector extends React.Component {
     componentDidMount() {
         const {
@@ -75,20 +81,24 @@ class SerialPortSelector extends React.Component {
             onSelect,
             isLoading,
             menuItemCssClass,
+            filterPort,
         } = this.props;
 
         if (!isLoading) {
-            return ports.map(port => (
-                <MenuItem
-                    key={port.comName}
-                    className={menuItemCssClass}
-                    eventKey={port.comName}
-                    onSelect={() => onSelect(port)}
-                >
-                    <div>{port.comName}</div>
-                    <div style={{ fontSize: 'small' }}>{port.serialNumber || ''}</div>
-                </MenuItem>
-            ));
+            return ports
+                .filter(filterPort)
+                .map(port => (
+                    <MenuItem
+                        key={port.comName}
+                        className={menuItemCssClass}
+                        eventKey={port.comName}
+                        onSelect={() => onSelect(port)}
+                    >
+                        <div>{port.comName}</div>
+                        <div style={{ fontSize: 'small' }}>{port.serialNumber || ''}</div>
+                    </MenuItem>
+                ),
+            );
         }
         return null;
     }
@@ -175,6 +185,7 @@ SerialPortSelector.propTypes = {
     dropdownCssClass: PropTypes.string,
     dropdownMenuCssClass: PropTypes.string,
     menuItemCssClass: PropTypes.string,
+    filterPort: PropTypes.func.isRequired,
 };
 
 SerialPortSelector.defaultProps = {
@@ -188,6 +199,7 @@ SerialPortSelector.defaultProps = {
     dropdownCssClass: 'core-serial-port-selector core-btn btn-primary',
     dropdownMenuCssClass: 'core-dropdown-menu',
     menuItemCssClass: 'btn-primary',
+    filterPort: filterSeggerPorts,
 };
 
 export default SerialPortSelector;

--- a/lib/windows/app/components/__tests__/SerialPortSelector-test.jsx
+++ b/lib/windows/app/components/__tests__/SerialPortSelector-test.jsx
@@ -53,6 +53,8 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import SerialPortSelector from '../SerialPortSelector';
 
+const SEGGER_VENDOR_ID = '0x1366';
+
 describe('SerialPortSelector', () => {
     it('should render empty port list, not expanded', () => {
         expect(renderer.create(
@@ -86,9 +88,11 @@ describe('SerialPortSelector', () => {
                     {
                         comName: '/dev/tty0',
                         serialNumber: '123456',
+                        vendorId: SEGGER_VENDOR_ID,
                     }, {
                         comName: '/dev/tty1',
                         serialNumber: '456789',
+                        vendorId: SEGGER_VENDOR_ID,
                     },
                 ]}
                 isExpanded
@@ -100,6 +104,53 @@ describe('SerialPortSelector', () => {
         )).toMatchSnapshot();
     });
 
+    it('should render only segger ports by default filter', () => {
+        expect(renderer.create(
+            <SerialPortSelector
+                ports={[
+                    {
+                        comName: '/dev/tty0',
+                        serialNumber: '123456',
+                        vendorId: '0x1234',
+                    }, {
+                        comName: '/dev/tty1',
+                        serialNumber: '456789',
+                        vendorId: SEGGER_VENDOR_ID,
+                    },
+                ]}
+                isExpanded
+                toggleExpanded={() => {}}
+                onSelect={() => {}}
+                onDeselect={() => {}}
+                bindHotkey={() => {}}
+            />,
+        )).toMatchSnapshot();
+    });
+
+    it('should render filtered ports', () => {
+        expect(renderer.create(
+            <SerialPortSelector
+                ports={[
+                    {
+                        comName: '/dev/tty0',
+                        serialNumber: '123456',
+                        vendorId: '0x1234',
+                    }, {
+                        comName: '/dev/tty1',
+                        serialNumber: '456789',
+                        vendorId: SEGGER_VENDOR_ID,
+                    },
+                ]}
+                isExpanded
+                toggleExpanded={() => {}}
+                onSelect={() => {}}
+                onDeselect={() => {}}
+                bindHotkey={() => {}}
+                filterPort={port => port.serialNumber === '123456'}
+            />,
+        )).toMatchSnapshot();
+    });
+
     it('should render two ports, one selected', () => {
         expect(renderer.create(
             <SerialPortSelector
@@ -107,9 +158,11 @@ describe('SerialPortSelector', () => {
                     {
                         comName: '/dev/tty0',
                         serialNumber: '123456',
+                        vendorId: SEGGER_VENDOR_ID,
                     }, {
                         comName: '/dev/tty1',
                         serialNumber: '456789',
+                        vendorId: SEGGER_VENDOR_ID,
                     },
                 ]}
                 selectedPort={'/dev/tty1'}
@@ -129,6 +182,7 @@ describe('SerialPortSelector', () => {
                     {
                         comName: '/dev/tty0',
                         serialNumber: '123456',
+                        vendorId: SEGGER_VENDOR_ID,
                     },
                 ]}
                 isExpanded
@@ -148,6 +202,7 @@ describe('SerialPortSelector', () => {
                     {
                         comName: '/dev/tty0',
                         serialNumber: '123456',
+                        vendorId: SEGGER_VENDOR_ID,
                     },
                 ]}
                 selectedPort={'/dev/tty0'}

--- a/lib/windows/app/components/__tests__/SerialPortSelector-test.jsx
+++ b/lib/windows/app/components/__tests__/SerialPortSelector-test.jsx
@@ -146,7 +146,7 @@ describe('SerialPortSelector', () => {
                 onSelect={() => {}}
                 onDeselect={() => {}}
                 bindHotkey={() => {}}
-                filterPort={port => port.serialNumber === '123456'}
+                filter={port => port.serialNumber === '123456'}
             />,
         )).toMatchSnapshot();
     });

--- a/lib/windows/app/components/__tests__/__snapshots__/SerialPortSelector-test.jsx.snap
+++ b/lib/windows/app/components/__tests__/__snapshots__/SerialPortSelector-test.jsx.snap
@@ -112,6 +112,100 @@ exports[`SerialPortSelector should render empty port list, not expanded 1`] = `
 </span>
 `;
 
+exports[`SerialPortSelector should render filtered ports 1`] = `
+<span
+  title="Select serial port (Alt+P)"
+>
+  <div
+    className="core-padded-row"
+  >
+    <Dropdown
+      id="serial-port-selector"
+      onToggle={[Function]}
+      open={true}
+    >
+      <DropdownToggle
+        className="core-serial-port-selector core-btn btn-primary"
+        title="Select serial port"
+      />
+      <DropdownMenu
+        className="core-dropdown-menu"
+        id="serial-port-selector-list"
+      >
+        <MenuItem
+          className="btn-primary"
+          eventKey="/dev/tty0"
+          onSelect={[Function]}
+        >
+          <div>
+            /dev/tty0
+          </div>
+          <div
+            style={
+              Object {
+                "fontSize": "small",
+              }
+            }
+          >
+            123456
+          </div>
+        </MenuItem>
+      </DropdownMenu>
+    </Dropdown>
+    <div
+      className="core-serial-port-indicator off"
+    />
+  </div>
+</span>
+`;
+
+exports[`SerialPortSelector should render only segger ports by default filter 1`] = `
+<span
+  title="Select serial port (Alt+P)"
+>
+  <div
+    className="core-padded-row"
+  >
+    <Dropdown
+      id="serial-port-selector"
+      onToggle={[Function]}
+      open={true}
+    >
+      <DropdownToggle
+        className="core-serial-port-selector core-btn btn-primary"
+        title="Select serial port"
+      />
+      <DropdownMenu
+        className="core-dropdown-menu"
+        id="serial-port-selector-list"
+      >
+        <MenuItem
+          className="btn-primary"
+          eventKey="/dev/tty1"
+          onSelect={[Function]}
+        >
+          <div>
+            /dev/tty1
+          </div>
+          <div
+            style={
+              Object {
+                "fontSize": "small",
+              }
+            }
+          >
+            456789
+          </div>
+        </MenuItem>
+      </DropdownMenu>
+    </Dropdown>
+    <div
+      className="core-serial-port-indicator off"
+    />
+  </div>
+</span>
+`;
+
 exports[`SerialPortSelector should render two ports 1`] = `
 <span
   title="Select serial port (Alt+P)"

--- a/lib/windows/app/reducers/__tests__/serialPortReducer-test.js
+++ b/lib/windows/app/reducers/__tests__/serialPortReducer-test.js
@@ -70,25 +70,6 @@ describe('serialPortReducer', () => {
         expect(state.isLoading).toEqual(false);
     });
 
-    it('should add segger ports to state when loading ports has succeeded', () => {
-        const unknownVendorPort = {
-            comName: '/dev/tty1',
-            vendorId: '0x01',
-        };
-        const seggerPort = {
-            comName: '/dev/tty2',
-            vendorId: SEGGER_VENDOR_ID,
-        };
-
-        const state = reducer(initialState, {
-            type: SerialPortActions.SERIAL_PORTS_LOAD_SUCCESS,
-            ports: [unknownVendorPort, seggerPort],
-        });
-
-        expect(state.ports.size).toEqual(1);
-        expect(state.ports.first().comName).toEqual(seggerPort.comName);
-    });
-
     it('should add port metadata to state when loading ports has succeeded', () => {
         const seggerPort = {
             comName: '/dev/tty1',
@@ -112,7 +93,7 @@ describe('serialPortReducer', () => {
         });
     });
 
-    it('should set serial number to -1 if it is not a number', () => {
+    it('should set serial number to "undefined" if it is not a number', () => {
         const seggerPort = {
             vendorId: SEGGER_VENDOR_ID,
             serialNumber: 'foobar',
@@ -124,7 +105,7 @@ describe('serialPortReducer', () => {
         });
 
         const port = state.ports.first().toJS();
-        expect(port.serialNumber).toEqual(-1);
+        expect(port.serialNumber).toBeUndefined();
     });
 
     it('should set selected port comPort when port has been selected', () => {

--- a/lib/windows/app/reducers/serialPortReducer.js
+++ b/lib/windows/app/reducers/serialPortReducer.js
@@ -38,7 +38,6 @@ import { Record, List } from 'immutable';
 import { getImmutableSerialPort } from '../models';
 import * as SerialPortActions from '../actions/serialPortActions';
 
-const SEGGER_VENDOR_IDS = new Set(['0x1366', '1366']);
 const SEGGER_SERIAL_PREFIX = 'SEGGER_J-Link_';
 
 const InitialState = Record({
@@ -59,12 +58,11 @@ function removeSeggerPrefix(serialNumber) {
 
 function cleanSerialNumber(serialNumber) {
     const number = parseInt(removeSeggerPrefix(serialNumber), 10);
-    return isNaN(number) ? -1 : number;
+    return isNaN(number) ? undefined : number;
 }
 
 function getSeggerPorts(ports) {
     return ports
-        .filter(port => SEGGER_VENDOR_IDS.has(port.vendorId))
         .map(port => {
             const serialPort = Object.assign(port, {
                 serialNumber: cleanSerialNumber(port.serialNumber),


### PR DESCRIPTION
Moved functionality of filtering serial ports by SEGGER vendor id to SerialPortSelector components filterPort() property function which can be overloaded by apps to access all/any serial ports.