### PR TITLE
Do not navigate when user drags and drops file

### DIFF
--- a/main/browser.js
+++ b/main/browser.js
@@ -73,6 +73,12 @@ function createWindow(options) {
 
     browserWindow.loadURL(options.url);
 
+    // Never navigate away from the given url, e.g. when the
+    // user drags and drops a file into the browser window.
+    browserWindow.webContents.on('will-navigate', event => {
+        event.preventDefault();
+    });
+
     browserWindow.webContents.on('did-finish-load', () => {
         if (splashScreen && !splashScreen.isDestroyed()) {
             splashScreen.close();


### PR DESCRIPTION
By default, when the user drags and drops a file into the browser window, it navigates away from our web application. Preventing this by overriding the default "will-navigate" event, ref:
https://discuss.atom.io/t/prevent-window-navigation-when-dropping-a-link/24365