### PR TITLE
Show information dialog if proxy login is cancelled

### DIFF
--- a/lib/windows/launcher/actions/proxyActions.js
+++ b/lib/windows/launcher/actions/proxyActions.js
@@ -38,6 +38,7 @@ import * as ErrorDialogActions from '../../../actions/errorDialogActions';
 
 export const PROXY_LOGIN_REQUESTED_BY_SERVER = 'PROXY_LOGIN_REQUESTED_BY_SERVER';
 export const PROXY_LOGIN_CANCELLED_BY_USER = 'PROXY_LOGIN_CANCELLED_BY_USER';
+export const PROXY_LOGIN_ERROR_DIALOG_CLOSED = 'PROXY_LOGIN_ERROR_DIALOG_CLOSED';
 export const PROXY_LOGIN_DIALOG_USERNAME_CHANGED = 'PROXY_LOGIN_DIALOG_USERNAME_CHANGED';
 export const PROXY_LOGIN_REQUEST_SENT = 'PROXY_LOGIN_REQUEST_SENT';
 export const PROXY_LOGIN_REQUEST_ERROR = 'PROXY_LOGIN_REQUEST_ERROR';
@@ -74,6 +75,12 @@ export function changeUserName(username) {
     return {
         type: PROXY_LOGIN_DIALOG_USERNAME_CHANGED,
         username,
+    };
+}
+
+export function loginErrorDialogClosedAction() {
+    return {
+        type: PROXY_LOGIN_ERROR_DIALOG_CLOSED,
     };
 }
 

--- a/lib/windows/launcher/components/ProxyErrorDialog.jsx
+++ b/lib/windows/launcher/components/ProxyErrorDialog.jsx
@@ -34,46 +34,40 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as ProxyActions from '../../actions/proxyActions';
-import reducer from '../proxyReducer';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button, ModalHeader, ModalFooter, ModalBody, ModalTitle } from 'react-bootstrap';
 
-const initialState = reducer(undefined, {});
+const ProxyErrorDialog = ({
+    isVisible,
+    onOk,
+}) => (
+    <Modal show={isVisible} backdrop>
+        <ModalHeader>
+            <ModalTitle>Proxy error</ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+            <p>
+                It appears that you are having problems authenticating with a proxy server.
+                This will prevent you from using certain features of nRF Connect, such as
+                installing apps from the &quot;Add/remove apps&quot; screen.
+            </p>
+            <p>
+                If you are unable to resolve the issue, then go to Settings and disable
+                &quot;Check for updates at startup&quot;. Then restart nRF Connect and
+                install apps manually by following the instructions at
+                https://github.com/NordicSemiconductor/pc-nrfconnect-core.
+            </p>
+        </ModalBody>
+        <ModalFooter>
+            <Button onClick={onOk}>OK</Button>
+        </ModalFooter>
+    </Modal>
+);
 
-describe('proxyReducer', () => {
-    it('should show login dialog with message when PROXY_LOGIN_REQUESTED_BY_SERVER has been dispatched', () => {
-        const state = reducer(initialState, {
-            type: ProxyActions.PROXY_LOGIN_REQUESTED_BY_SERVER,
-            message: 'Please enter proxy credentials',
-        });
-        expect(state.isLoginDialogVisible).toEqual(true);
-        expect(state.loginDialogMessage).toEqual('Please enter proxy credentials');
-    });
+ProxyErrorDialog.propTypes = {
+    isVisible: PropTypes.bool.isRequired,
+    onOk: PropTypes.func.isRequired,
+};
 
-    it('should hide login dialog when PROXY_LOGIN_CANCELLED_BY_USER has been dispatched', () => {
-        const state = reducer(initialState.set('isLoginDialogVisible', true), {
-            type: ProxyActions.PROXY_LOGIN_CANCELLED_BY_USER,
-        });
-        expect(state.isLoginDialogVisible).toEqual(false);
-    });
-
-    it('should show login error dialog when PROXY_LOGIN_CANCELLED_BY_USER has been dispatched', () => {
-        const state = reducer(initialState, {
-            type: ProxyActions.PROXY_LOGIN_CANCELLED_BY_USER,
-        });
-        expect(state.isErrorDialogVisible).toEqual(true);
-    });
-
-    it('should hide login error dialog when PROXY_LOGIN_ERROR_DIALOG_CLOSED has been dispatched', () => {
-        const state = reducer(initialState.set('isErrorDialogVisible', true), {
-            type: ProxyActions.PROXY_LOGIN_ERROR_DIALOG_CLOSED,
-        });
-        expect(state.isErrorDialogVisible).toEqual(false);
-    });
-
-    it('should hide login dialog when PROXY_LOGIN_REQUEST_SENT has been dispatched', () => {
-        const state = reducer(initialState.set('isLoginDialogVisible', true), {
-            type: ProxyActions.PROXY_LOGIN_REQUEST_SENT,
-        });
-        expect(state.isLoginDialogVisible).toEqual(false);
-    });
-});
+export default ProxyErrorDialog;

--- a/lib/windows/launcher/components/Root.jsx
+++ b/lib/windows/launcher/components/Root.jsx
@@ -42,6 +42,7 @@ import UpdateAvailableContainer from '../containers/UpdateAvailableContainer';
 import UpdateProgressContainer from '../containers/UpdateProgressContainer';
 import ConfirmLaunchContainer from '../containers/ConfirmLaunchContainer';
 import ProxyLoginContainer from '../containers/ProxyLoginContainer';
+import ProxyErrorContainer from '../containers/ProxyErrorContainer';
 import Logo from '../../../components/Logo';
 
 export default () => (
@@ -58,5 +59,6 @@ export default () => (
         <UpdateProgressContainer />
         <ConfirmLaunchContainer />
         <ProxyLoginContainer />
+        <ProxyErrorContainer />
     </div>
 );

--- a/lib/windows/launcher/containers/ProxyErrorContainer.js
+++ b/lib/windows/launcher/containers/ProxyErrorContainer.js
@@ -34,46 +34,25 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as ProxyActions from '../../actions/proxyActions';
-import reducer from '../proxyReducer';
+import { connect } from 'react-redux';
+import ProxyErrorDialog from '../components/ProxyErrorDialog';
+import * as ProxyActions from '../actions/proxyActions';
 
-const initialState = reducer(undefined, {});
+function mapStateToProps(state) {
+    const { proxy } = state;
 
-describe('proxyReducer', () => {
-    it('should show login dialog with message when PROXY_LOGIN_REQUESTED_BY_SERVER has been dispatched', () => {
-        const state = reducer(initialState, {
-            type: ProxyActions.PROXY_LOGIN_REQUESTED_BY_SERVER,
-            message: 'Please enter proxy credentials',
-        });
-        expect(state.isLoginDialogVisible).toEqual(true);
-        expect(state.loginDialogMessage).toEqual('Please enter proxy credentials');
-    });
+    return {
+        isVisible: proxy.isErrorDialogVisible,
+    };
+}
 
-    it('should hide login dialog when PROXY_LOGIN_CANCELLED_BY_USER has been dispatched', () => {
-        const state = reducer(initialState.set('isLoginDialogVisible', true), {
-            type: ProxyActions.PROXY_LOGIN_CANCELLED_BY_USER,
-        });
-        expect(state.isLoginDialogVisible).toEqual(false);
-    });
+function mapDispatchToProps(dispatch) {
+    return {
+        onOk: () => dispatch(ProxyActions.loginErrorDialogClosedAction()),
+    };
+}
 
-    it('should show login error dialog when PROXY_LOGIN_CANCELLED_BY_USER has been dispatched', () => {
-        const state = reducer(initialState, {
-            type: ProxyActions.PROXY_LOGIN_CANCELLED_BY_USER,
-        });
-        expect(state.isErrorDialogVisible).toEqual(true);
-    });
-
-    it('should hide login error dialog when PROXY_LOGIN_ERROR_DIALOG_CLOSED has been dispatched', () => {
-        const state = reducer(initialState.set('isErrorDialogVisible', true), {
-            type: ProxyActions.PROXY_LOGIN_ERROR_DIALOG_CLOSED,
-        });
-        expect(state.isErrorDialogVisible).toEqual(false);
-    });
-
-    it('should hide login dialog when PROXY_LOGIN_REQUEST_SENT has been dispatched', () => {
-        const state = reducer(initialState.set('isLoginDialogVisible', true), {
-            type: ProxyActions.PROXY_LOGIN_REQUEST_SENT,
-        });
-        expect(state.isLoginDialogVisible).toEqual(false);
-    });
-});
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(ProxyErrorDialog);

--- a/lib/windows/launcher/reducers/proxyReducer.js
+++ b/lib/windows/launcher/reducers/proxyReducer.js
@@ -40,6 +40,7 @@ import * as ProxyActions from '../actions/proxyActions';
 const InitialState = Record({
     username: '',
     isLoginDialogVisible: false,
+    isErrorDialogVisible: false,
     loginDialogMessage: '',
 });
 const initialState = new InitialState();
@@ -54,6 +55,11 @@ function hideLoginDialog(state) {
         .set('isLoginDialogVisible', false);
 }
 
+function cancelLoginDialog(state) {
+    return hideLoginDialog(state)
+        .set('isErrorDialogVisible', true);
+}
+
 function setLoginRequestSent(state, username) {
     return hideLoginDialog(state)
         .set('username', username);
@@ -64,7 +70,9 @@ const reducer = (state = initialState, action) => {
         case ProxyActions.PROXY_LOGIN_REQUESTED_BY_SERVER:
             return showLoginDialog(state, action.message);
         case ProxyActions.PROXY_LOGIN_CANCELLED_BY_USER:
-            return hideLoginDialog(state);
+            return cancelLoginDialog(state);
+        case ProxyActions.PROXY_LOGIN_ERROR_DIALOG_CLOSED:
+            return state.set('isErrorDialogVisible', false);
         case ProxyActions.PROXY_LOGIN_DIALOG_USERNAME_CHANGED:
             return state.set('username', action.username);
         case ProxyActions.PROXY_LOGIN_REQUEST_SENT:


### PR DESCRIPTION
If the user is behind a proxy that requires authentication, and cancels the proxy login dialog, then app installation and checking for updates will fail. Showing some (hopefully) helpful text to the user in this situation, so that the user can disable checking for updates at startup and install apps manually instead.