### PR TITLE
Show dialog after manual check for updates

### DIFF
--- a/lib/components/ConfirmationDialog.jsx
+++ b/lib/components/ConfirmationDialog.jsx
@@ -55,7 +55,12 @@ const ConfirmationDialog = ({
                 { isInProgress ? <Spinner /> : null }
                 &nbsp;
                 <Button onClick={onOk} disabled={isInProgress}>{okButtonText}</Button>
-                <Button onClick={onCancel} disabled={isInProgress}>{cancelButtonText}</Button>
+                {
+                    onCancel &&
+                        <Button onClick={onCancel} disabled={isInProgress}>
+                            {cancelButtonText}
+                        </Button>
+                }
             </ModalFooter>
         </Modal>
     </div>
@@ -66,7 +71,7 @@ ConfirmationDialog.propTypes = {
     title: PropTypes.string,
     text: PropTypes.string.isRequired,
     onOk: PropTypes.func.isRequired,
-    onCancel: PropTypes.func.isRequired,
+    onCancel: PropTypes.func,
     okButtonText: PropTypes.string,
     cancelButtonText: PropTypes.string,
     isInProgress: PropTypes.bool,
@@ -75,6 +80,7 @@ ConfirmationDialog.propTypes = {
 ConfirmationDialog.defaultProps = {
     title: 'Confirm',
     isInProgress: false,
+    onCancel: null,
     okButtonText: 'OK',
     cancelButtonText: 'Cancel',
 };

--- a/lib/components/__tests__/ConfirmationDialog-test.jsx
+++ b/lib/components/__tests__/ConfirmationDialog-test.jsx
@@ -84,4 +84,14 @@ describe('ConfirmationDialog', () => {
             />,
         )).toMatchSnapshot();
     });
+
+    it('should not render cancel button if onCancel function is not provided', () => {
+        expect(renderer.create(
+            <ConfirmationDialog
+                isVisible
+                text="Something happened."
+                onOk={() => {}}
+            />,
+        )).toMatchSnapshot();
+    });
 });

--- a/lib/components/__tests__/__snapshots__/ConfirmationDialog-test.jsx.snap
+++ b/lib/components/__tests__/__snapshots__/ConfirmationDialog-test.jsx.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ConfirmationDialog should not render cancel button if onCancel function is not provided 1`] = `
+<div>
+  <Modal
+    backdrop={false}
+    onHide={null}
+    show={true}
+  >
+    <ModalHeader
+      closeButton={true}
+    >
+      <ModalTitle>
+        Confirm
+      </ModalTitle>
+    </ModalHeader>
+    <ModalBody>
+      <p>
+        Something happened.
+      </p>
+    </ModalBody>
+    <ModalFooter>
+       
+      <Button
+        disabled={false}
+        onClick={[Function]}
+      >
+        OK
+      </Button>
+    </ModalFooter>
+  </Modal>
+</div>
+`;
+
 exports[`ConfirmationDialog should render invisible dialog 1`] = `
 <div>
   <Modal

--- a/lib/windows/launcher/actions/settingsActions.js
+++ b/lib/windows/launcher/actions/settingsActions.js
@@ -43,6 +43,8 @@ export const SETTINGS_LOAD = 'SETTINGS_LOAD';
 export const SETTINGS_LOAD_SUCCESS = 'SETTINGS_LOAD_SUCCESS';
 export const SETTINGS_LOAD_ERROR = 'SETTINGS_LOAD_ERROR';
 export const SETTINGS_CHECK_UPDATES_AT_STARTUP_CHANGED = 'SETTINGS_CHECK_UPDATES_AT_STARTUP_CHANGED';
+export const SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_SHOW = 'SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_SHOW';
+export const SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE = 'SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE';
 
 function loadSettingsAction() {
     return {
@@ -97,5 +99,17 @@ export function checkUpdatesAtStartupChanged(isEnabled) {
         } catch (error) {
             dispatch(ErrorDialogActions.showDialog(`Unable to save settings: ${error.message}`));
         }
+    };
+}
+
+export function showUpdateCheckCompleteDialog() {
+    return {
+        type: SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_SHOW,
+    };
+}
+
+export function hideUpdateCheckCompleteDialog() {
+    return {
+        type: SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE,
     };
 }

--- a/lib/windows/launcher/components/SettingsView.jsx
+++ b/lib/windows/launcher/components/SettingsView.jsx
@@ -38,6 +38,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox } from 'react-bootstrap';
 import moment from 'moment';
+import UpdateCheckCompleteDialog from './UpdateCheckCompleteDialog';
 
 class SettingsView extends React.Component {
     constructor() {
@@ -65,6 +66,9 @@ class SettingsView extends React.Component {
             shouldCheckForUpdatesAtStartup,
             isCheckingForUpdates,
             lastUpdateCheckDate,
+            isUpdateCheckCompleteDialogVisible,
+            onHideUpdateCheckCompleteDialog,
+            isAppUpdateAvailable,
         } = this.props;
 
         const checkButtonText = isCheckingForUpdates ? 'Checking...' : 'Check for updates now';
@@ -98,6 +102,14 @@ class SettingsView extends React.Component {
                         </button>
                     </div>
                 </div>
+                {
+                    isUpdateCheckCompleteDialogVisible &&
+                        <UpdateCheckCompleteDialog
+                            isVisible
+                            isAppUpdateAvailable={isAppUpdateAvailable}
+                            onOk={onHideUpdateCheckCompleteDialog}
+                        />
+                }
             </div>
         ) : <div />;
     }
@@ -111,11 +123,16 @@ SettingsView.propTypes = {
     onCheckUpdatesAtStartupChanged: PropTypes.func.isRequired,
     onTriggerUpdateCheck: PropTypes.func.isRequired,
     lastUpdateCheckDate: PropTypes.instanceOf(Date),
+    isUpdateCheckCompleteDialogVisible: PropTypes.bool,
+    onHideUpdateCheckCompleteDialog: PropTypes.func.isRequired,
+    isAppUpdateAvailable: PropTypes.bool,
 };
 
 SettingsView.defaultProps = {
     onMount: () => {},
     lastUpdateCheckDate: null,
+    isUpdateCheckCompleteDialogVisible: false,
+    isAppUpdateAvailable: false,
 };
 
 export default SettingsView;

--- a/lib/windows/launcher/components/UpdateCheckCompleteDialog.jsx
+++ b/lib/windows/launcher/components/UpdateCheckCompleteDialog.jsx
@@ -1,0 +1,65 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ConfirmationDialog from '../../../components/ConfirmationDialog';
+
+const UpdateCheckSuccessDialog = ({
+    isVisible,
+    isAppUpdateAvailable,
+    onOk,
+}) => (
+    <ConfirmationDialog
+        isVisible={isVisible}
+        title="Update check completed"
+        text={
+            isAppUpdateAvailable ?
+                'One or more updates are available. Go to the Add/remove apps screen to upgrade.' :
+                'All apps are up to date.'
+        }
+        onOk={onOk}
+    />
+);
+
+UpdateCheckSuccessDialog.propTypes = {
+    isVisible: PropTypes.bool.isRequired,
+    isAppUpdateAvailable: PropTypes.bool.isRequired,
+    onOk: PropTypes.func.isRequired,
+};
+
+export default UpdateCheckSuccessDialog;

--- a/lib/windows/launcher/components/__tests__/SettingsView-test.jsx
+++ b/lib/windows/launcher/components/__tests__/SettingsView-test.jsx
@@ -34,6 +34,19 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* eslint-disable import/first */
+
+// Do not render react-bootstrap components in tests
+jest.mock('react-bootstrap', () => ({
+    Modal: 'Modal',
+    Button: 'Button',
+    ModalHeader: 'ModalHeader',
+    ModalFooter: 'ModalFooter',
+    ModalBody: 'ModalBody',
+    ModalTitle: 'ModalTitle',
+    Checkbox: 'Checkbox',
+}));
+
 import React from 'react';
 import renderer from 'react-test-renderer';
 import SettingsView from '../SettingsView';
@@ -47,6 +60,7 @@ describe('SettingsView', () => {
                 isCheckingForUpdates={false}
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
+                onHideUpdateCheckCompleteDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -59,6 +73,7 @@ describe('SettingsView', () => {
                 isCheckingForUpdates={false}
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
+                onHideUpdateCheckCompleteDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -71,6 +86,7 @@ describe('SettingsView', () => {
                 isCheckingForUpdates={false}
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
+                onHideUpdateCheckCompleteDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -83,6 +99,7 @@ describe('SettingsView', () => {
                 isCheckingForUpdates
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
+                onHideUpdateCheckCompleteDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -96,6 +113,39 @@ describe('SettingsView', () => {
                 lastUpdateCheckDate={new Date(2017, 1, 3, 13, 41, 36, 20)}
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
+                onHideUpdateCheckCompleteDialog={() => {}}
+            />,
+        )).toMatchSnapshot();
+    });
+
+    it('should render check for updates completed, with updates available', () => {
+        expect(renderer.create(
+            <SettingsView
+                isLoading={false}
+                shouldCheckForUpdatesAtStartup={false}
+                isCheckingForUpdates={false}
+                lastUpdateCheckDate={new Date(2017, 1, 3, 13, 41, 36, 20)}
+                onTriggerUpdateCheck={() => {}}
+                onCheckUpdatesAtStartupChanged={() => {}}
+                onHideUpdateCheckCompleteDialog={() => {}}
+                isUpdateCheckCompleteDialogVisible
+                isAppUpdateAvailable
+            />,
+        )).toMatchSnapshot();
+    });
+
+    it('should render check for updates completed, with everything up to date', () => {
+        expect(renderer.create(
+            <SettingsView
+                isLoading={false}
+                shouldCheckForUpdatesAtStartup={false}
+                isCheckingForUpdates={false}
+                lastUpdateCheckDate={new Date(2017, 1, 3, 13, 41, 36, 20)}
+                onTriggerUpdateCheck={() => {}}
+                onCheckUpdatesAtStartupChanged={() => {}}
+                onHideUpdateCheckCompleteDialog={() => {}}
+                isUpdateCheckCompleteDialogVisible
+                isAppUpdateAvailable={false}
             />,
         )).toMatchSnapshot();
     });

--- a/lib/windows/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
@@ -1,5 +1,145 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SettingsView should render check for updates completed, with everything up to date 1`] = `
+<div>
+  <div
+    className="core-settings-section"
+  >
+    <h4>
+      Updates
+    </h4>
+    <p>
+      Last update check performed: 
+      2017-02-03 13:41:36
+    </p>
+    <div
+      className="core-settings-update-check-controls"
+    >
+      <Checkbox
+        checked={false}
+        onChange={[Function]}
+      >
+        Check for updates at startup
+      </Checkbox>
+      <button
+        className="btn btn-primary core-btn"
+        disabled={false}
+        onClick={[Function]}
+        title="Check for updates now"
+      >
+        <span
+          className="glyphicon glyphicon-refresh"
+        />
+        <span
+          className="core-btn-text"
+        >
+          Check for updates now
+        </span>
+      </button>
+    </div>
+  </div>
+  <div>
+    <Modal
+      backdrop={false}
+      onHide={null}
+      show={true}
+    >
+      <ModalHeader
+        closeButton={true}
+      >
+        <ModalTitle>
+          Update check completed
+        </ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        <p>
+          All apps are up to date.
+        </p>
+      </ModalBody>
+      <ModalFooter>
+         
+        <Button
+          disabled={false}
+          onClick={[Function]}
+        >
+          OK
+        </Button>
+      </ModalFooter>
+    </Modal>
+  </div>
+</div>
+`;
+
+exports[`SettingsView should render check for updates completed, with updates available 1`] = `
+<div>
+  <div
+    className="core-settings-section"
+  >
+    <h4>
+      Updates
+    </h4>
+    <p>
+      Last update check performed: 
+      2017-02-03 13:41:36
+    </p>
+    <div
+      className="core-settings-update-check-controls"
+    >
+      <Checkbox
+        checked={false}
+        onChange={[Function]}
+      >
+        Check for updates at startup
+      </Checkbox>
+      <button
+        className="btn btn-primary core-btn"
+        disabled={false}
+        onClick={[Function]}
+        title="Check for updates now"
+      >
+        <span
+          className="glyphicon glyphicon-refresh"
+        />
+        <span
+          className="core-btn-text"
+        >
+          Check for updates now
+        </span>
+      </button>
+    </div>
+  </div>
+  <div>
+    <Modal
+      backdrop={false}
+      onHide={null}
+      show={true}
+    >
+      <ModalHeader
+        closeButton={true}
+      >
+        <ModalTitle>
+          Update check completed
+        </ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        <p>
+          One or more updates are available. Go to the Add/remove apps screen to upgrade.
+        </p>
+      </ModalBody>
+      <ModalFooter>
+         
+        <Button
+          disabled={false}
+          onClick={[Function]}
+        >
+          OK
+        </Button>
+      </ModalFooter>
+    </Modal>
+  </div>
+</div>
+`;
+
 exports[`SettingsView should render empty div while loading 1`] = `<div />`;
 
 exports[`SettingsView should render when checking for updates 1`] = `
@@ -13,20 +153,12 @@ exports[`SettingsView should render when checking for updates 1`] = `
     <div
       className="core-settings-update-check-controls"
     >
-      <div
-        className="checkbox"
-        style={undefined}
+      <Checkbox
+        checked={false}
+        onChange={[Function]}
       >
-        <label>
-          <input
-            checked={false}
-            disabled={false}
-            onChange={[Function]}
-            type="checkbox"
-          />
-          Check for updates at startup
-        </label>
-      </div>
+        Check for updates at startup
+      </Checkbox>
       <button
         className="btn btn-primary core-btn"
         disabled={true}
@@ -58,20 +190,12 @@ exports[`SettingsView should render with check for updates disabled 1`] = `
     <div
       className="core-settings-update-check-controls"
     >
-      <div
-        className="checkbox"
-        style={undefined}
+      <Checkbox
+        checked={false}
+        onChange={[Function]}
       >
-        <label>
-          <input
-            checked={false}
-            disabled={false}
-            onChange={[Function]}
-            type="checkbox"
-          />
-          Check for updates at startup
-        </label>
-      </div>
+        Check for updates at startup
+      </Checkbox>
       <button
         className="btn btn-primary core-btn"
         disabled={false}
@@ -103,20 +227,12 @@ exports[`SettingsView should render with check for updates enabled 1`] = `
     <div
       className="core-settings-update-check-controls"
     >
-      <div
-        className="checkbox"
-        style={undefined}
+      <Checkbox
+        checked={true}
+        onChange={[Function]}
       >
-        <label>
-          <input
-            checked={true}
-            disabled={false}
-            onChange={[Function]}
-            type="checkbox"
-          />
-          Check for updates at startup
-        </label>
-      </div>
+        Check for updates at startup
+      </Checkbox>
       <button
         className="btn btn-primary core-btn"
         disabled={false}
@@ -152,20 +268,12 @@ exports[`SettingsView should render with last update check date 1`] = `
     <div
       className="core-settings-update-check-controls"
     >
-      <div
-        className="checkbox"
-        style={undefined}
+      <Checkbox
+        checked={false}
+        onChange={[Function]}
       >
-        <label>
-          <input
-            checked={false}
-            disabled={false}
-            onChange={[Function]}
-            type="checkbox"
-          />
-          Check for updates at startup
-        </label>
-      </div>
+        Check for updates at startup
+      </Checkbox>
       <button
         className="btn btn-primary core-btn"
         disabled={false}

--- a/lib/windows/launcher/containers/SettingsContainer.js
+++ b/lib/windows/launcher/containers/SettingsContainer.js
@@ -40,6 +40,10 @@ import * as SettingsActions from '../actions/settingsActions';
 import * as AppsActions from '../actions/appsActions';
 import * as AutoUpdateActions from '../actions/autoUpdateActions';
 
+function isAppUpdateAvailable(officialApps) {
+    return officialApps.find(app => app.latestVersion && app.currentVersion !== app.latestVersion);
+}
+
 function mapStateToProps(state) {
     const { settings, apps } = state;
 
@@ -47,7 +51,9 @@ function mapStateToProps(state) {
         isLoading: settings.isLoading,
         shouldCheckForUpdatesAtStartup: settings.shouldCheckForUpdatesAtStartup,
         isCheckingForUpdates: apps.isDownloadingLatestAppInfo,
+        isUpdateCheckCompleteDialogVisible: settings.isUpdateCheckCompleteDialogVisible,
         lastUpdateCheckDate: apps.lastUpdateCheckDate,
+        isAppUpdateAvailable: isAppUpdateAvailable(apps.officialApps),
     };
 }
 
@@ -57,9 +63,13 @@ function mapDispatchToProps(dispatch) {
         onCheckUpdatesAtStartupChanged: isEnabled =>
             dispatch(SettingsActions.checkUpdatesAtStartupChanged(isEnabled)),
         onTriggerUpdateCheck: () => {
-            dispatch(AppsActions.downloadLatestAppInfo());
+            dispatch(AppsActions.downloadLatestAppInfo())
+                .then(() => dispatch(SettingsActions.showUpdateCheckCompleteDialog()));
             dispatch(AutoUpdateActions.checkForUpdates());
         },
+        onHideUpdateCheckCompleteDialog: () => (
+            dispatch(SettingsActions.hideUpdateCheckCompleteDialog())
+        ),
     };
 }
 

--- a/lib/windows/launcher/reducers/__tests__/settingsReducer-test.js
+++ b/lib/windows/launcher/reducers/__tests__/settingsReducer-test.js
@@ -117,4 +117,18 @@ describe('settingsReducer', () => {
         });
         expect(state.shouldCheckForUpdatesAtStartup).toEqual(false);
     });
+
+    it('should show update check complete dialog when SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_SHOW has been dispatched', () => {
+        const state = reducer(initialState, {
+            type: SettingsActions.SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_SHOW,
+        });
+        expect(state.isUpdateCheckCompleteDialogVisible).toEqual(true);
+    });
+
+    it('should not show update check complete dialog when SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE has been dispatched', () => {
+        const state = reducer(initialState.set('isUpdateCheckCompleteDialogVisible', true), {
+            type: SettingsActions.SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE,
+        });
+        expect(state.isUpdateCheckCompleteDialogVisible).toEqual(false);
+    });
 });

--- a/lib/windows/launcher/reducers/settingsReducer.js
+++ b/lib/windows/launcher/reducers/settingsReducer.js
@@ -39,6 +39,7 @@ import * as SettingsActions from '../actions/settingsActions';
 
 const InitialState = Record({
     shouldCheckForUpdatesAtStartup: true,
+    isUpdateCheckCompleteDialogVisible: false,
     isLoading: false,
 });
 
@@ -59,6 +60,10 @@ const reducer = (state = initialState, action) => {
             return state.set('isLoading', false);
         case SettingsActions.SETTINGS_CHECK_UPDATES_AT_STARTUP_CHANGED:
             return state.set('shouldCheckForUpdatesAtStartup', action.isEnabled);
+        case SettingsActions.SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_SHOW:
+            return state.set('isUpdateCheckCompleteDialogVisible', true);
+        case SettingsActions.SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE:
+            return state.set('isUpdateCheckCompleteDialogVisible', false);
         default:
             return state;
     }


### PR DESCRIPTION
Up until now there has been no feedback to the user after pressing the "Check for updates now" button in the Settings screen. Now popping up a dialog after the update check is complete, showing "All apps are up to date" or "One or more updates are available. Go to the Add/remove apps screen to upgrade".

![image](https://user-images.githubusercontent.com/461755/29027196-ee81ea8e-7b7f-11e7-8ea6-ad697f745344.png)
