### PR TITLE
Use the same session name as electron-updater

### DIFF
--- a/main/net.js
+++ b/main/net.js
@@ -38,6 +38,11 @@
 
 const fs = require('fs');
 const net = require('electron').net;
+const session = require('electron').session;
+
+// Using the same session name as electron-updater, so that proxy credentials
+// (if required) only have to be sent once.
+const NET_SESSION_NAME = 'electron-updater';
 
 let onProxyLogin;
 
@@ -56,7 +61,10 @@ function registerProxyLoginHandler(onLoginRequested) {
 
 function downloadToBuffer(url) {
     return new Promise((resolve, reject) => {
-        const request = net.request(url);
+        const request = net.request({
+            url,
+            session: session.fromPartition(NET_SESSION_NAME),
+        });
         request.setHeader('pragma', 'no-cache');
         request.on('response', response => {
             if (response.statusCode !== 200) {


### PR DESCRIPTION
When the user enters proxy credentials, they are cached in a session so that they do not have to be entered again. We have been using the default session from Electron. However, the electron-updater library performs network requests with a different session, using the ["electron-updater" session name](https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/electronHttpExecutor.ts). This means that proxy credentials have to be submitted twice - once for each session. To avoid this, we can use the same session that electron-updater is using for our own network requests.

We could consider adding a feature/pull request for electron-updater that allows configuring which session to use, which would be a cleaner solution in our case.