### PR TITLE
Fix proxy server issue with "Check for updates now" button

### DIFF
--- a/lib/windows/launcher/actions/appsActions.js
+++ b/lib/windows/launcher/actions/appsActions.js
@@ -193,7 +193,7 @@ export function hideConfirmLaunchDialogAction() {
     };
 }
 
-export function downloadLatestAppInfo() {
+export function downloadLatestAppInfo(options = { rejectIfError: false }) {
     return dispatch => {
         dispatch(downloadLatestAppInfoAction());
 
@@ -202,8 +202,12 @@ export function downloadLatestAppInfo() {
             .then(() => dispatch(downloadLatestAppInfoSuccessAction()))
             .catch(error => {
                 dispatch(downloadLatestAppInfoErrorAction());
-                dispatch(ErrorDialogActions.showDialog('Unable to download ' +
-                    `latest app info: ${error.message}`));
+                if (options.rejectIfError) {
+                    throw error;
+                } else {
+                    dispatch(ErrorDialogActions.showDialog('Unable to download ' +
+                        `latest app info: ${error.message}`));
+                }
             });
     };
 }

--- a/lib/windows/launcher/actions/autoUpdateActions.js
+++ b/lib/windows/launcher/actions/autoUpdateActions.js
@@ -103,7 +103,7 @@ export function postponeUpdate() {
     };
 }
 
-export function checkForUpdates() {
+export function checkForCoreUpdates() {
     return dispatch => {
         dispatch(checkAction());
 

--- a/lib/windows/launcher/actions/settingsActions.js
+++ b/lib/windows/launcher/actions/settingsActions.js
@@ -36,6 +36,8 @@
 
 import { remote } from 'electron';
 import * as ErrorDialogActions from '../../../actions/errorDialogActions';
+import * as AppsActions from './appsActions';
+import * as AutoUpdateActions from './autoUpdateActions';
 
 const settings = remote.require('./main/settings');
 
@@ -112,4 +114,14 @@ export function hideUpdateCheckCompleteDialog() {
     return {
         type: SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE,
     };
+}
+
+export function checkForUpdatesButtonClicked() {
+    return dispatch => (
+        dispatch(AppsActions.downloadLatestAppInfo())
+            .then(() => {
+                dispatch(AutoUpdateActions.checkForCoreUpdates());
+                dispatch(showUpdateCheckCompleteDialog());
+            })
+    );
 }

--- a/lib/windows/launcher/actions/settingsActions.js
+++ b/lib/windows/launcher/actions/settingsActions.js
@@ -118,10 +118,13 @@ export function hideUpdateCheckCompleteDialog() {
 
 export function checkForUpdatesButtonClicked() {
     return dispatch => (
-        dispatch(AppsActions.downloadLatestAppInfo())
+        dispatch(AppsActions.downloadLatestAppInfo({ rejectIfError: true }))
             .then(() => {
                 dispatch(AutoUpdateActions.checkForCoreUpdates());
                 dispatch(showUpdateCheckCompleteDialog());
             })
+            .catch(error => (
+                dispatch(ErrorDialogActions.showDialog(`Unable to check for updates: ${error.message}`))
+            ))
     );
 }

--- a/lib/windows/launcher/containers/SettingsContainer.js
+++ b/lib/windows/launcher/containers/SettingsContainer.js
@@ -37,8 +37,6 @@
 import { connect } from 'react-redux';
 import SettingsView from '../components/SettingsView';
 import * as SettingsActions from '../actions/settingsActions';
-import * as AppsActions from '../actions/appsActions';
-import * as AutoUpdateActions from '../actions/autoUpdateActions';
 
 function isAppUpdateAvailable(officialApps) {
     return officialApps.find(app => app.latestVersion && app.currentVersion !== app.latestVersion);
@@ -62,13 +60,9 @@ function mapDispatchToProps(dispatch) {
         onMount: () => dispatch(SettingsActions.loadSettings()),
         onCheckUpdatesAtStartupChanged: isEnabled =>
             dispatch(SettingsActions.checkUpdatesAtStartupChanged(isEnabled)),
-        onTriggerUpdateCheck: () => {
-            dispatch(AppsActions.downloadLatestAppInfo())
-                .then(() => {
-                    dispatch(AutoUpdateActions.checkForCoreUpdates());
-                    dispatch(SettingsActions.showUpdateCheckCompleteDialog());
-                });
-        },
+        onTriggerUpdateCheck: () => (
+            dispatch(SettingsActions.checkForUpdatesButtonClicked())
+        ),
         onHideUpdateCheckCompleteDialog: () => (
             dispatch(SettingsActions.hideUpdateCheckCompleteDialog())
         ),

--- a/lib/windows/launcher/containers/SettingsContainer.js
+++ b/lib/windows/launcher/containers/SettingsContainer.js
@@ -65,7 +65,7 @@ function mapDispatchToProps(dispatch) {
         onTriggerUpdateCheck: () => {
             dispatch(AppsActions.downloadLatestAppInfo())
                 .then(() => dispatch(SettingsActions.showUpdateCheckCompleteDialog()));
-            dispatch(AutoUpdateActions.checkForUpdates());
+            dispatch(AutoUpdateActions.checkForCoreUpdates());
         },
         onHideUpdateCheckCompleteDialog: () => (
             dispatch(SettingsActions.hideUpdateCheckCompleteDialog())

--- a/lib/windows/launcher/containers/SettingsContainer.js
+++ b/lib/windows/launcher/containers/SettingsContainer.js
@@ -64,8 +64,10 @@ function mapDispatchToProps(dispatch) {
             dispatch(SettingsActions.checkUpdatesAtStartupChanged(isEnabled)),
         onTriggerUpdateCheck: () => {
             dispatch(AppsActions.downloadLatestAppInfo())
-                .then(() => dispatch(SettingsActions.showUpdateCheckCompleteDialog()));
-            dispatch(AutoUpdateActions.checkForCoreUpdates());
+                .then(() => {
+                    dispatch(AutoUpdateActions.checkForCoreUpdates());
+                    dispatch(SettingsActions.showUpdateCheckCompleteDialog());
+                });
         },
         onHideUpdateCheckCompleteDialog: () => (
             dispatch(SettingsActions.hideUpdateCheckCompleteDialog())

--- a/lib/windows/launcher/index.js
+++ b/lib/windows/launcher/index.js
@@ -66,7 +66,7 @@ function downloadLatestAppInfo() {
 
 function checkForCoreUpdates() {
     if (shouldCheckForUpdatesAtStartup !== false && !config.isSkipUpdateCore() && !isDev) {
-        return store.dispatch(AutoUpdateActions.checkForUpdates());
+        return store.dispatch(AutoUpdateActions.checkForCoreUpdates());
     }
     return Promise.resolve();
 }

--- a/lib/windows/launcher/reducers/__tests__/settingsReducer-test.js
+++ b/lib/windows/launcher/reducers/__tests__/settingsReducer-test.js
@@ -37,7 +37,12 @@
 /* eslint-disable import/first */
 
 jest.mock('electron', () => ({
-    remote: { require: () => {} },
+    remote: {
+        require: () => ({
+            autoUpdater: {},
+            CancellationToken: class CancellationToken {},
+        }),
+    },
 }));
 
 import * as SettingsActions from '../../actions/settingsActions';


### PR DESCRIPTION
When the "Check for updates now" button is pressed, we check for both app updates and core updates. If the user is behind a proxy that requires authentication, then we cannot send the requests in parallel, because that would result in HTTP 407 responses for both requests.

We need to send one request first, which receives a HTTP 407, and allow the user to enter proxy credentials for that request. The next request will then use the cached credentials.