### PR TITLE
Mock fs-extra in fileUtil-test.js

### DIFF
--- a/main/__tests__/fileUtil-test.js
+++ b/main/__tests__/fileUtil-test.js
@@ -34,6 +34,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* eslint-disable import/first */
+
+jest.mock('fs-extra', () => ({}));
+
 import { getNameFromNpmPackage } from '../fileUtil';
 
 describe('getNameFromNpmPackage', () => {


### PR DESCRIPTION
After fs-extra was introduced in fileUtil.js, the unit tests started failing with error "TypeError: polyfills is not a function". Not sure why. The application still works as expected, so it seems to be related to the jest runtime. Mocking fs-extra as it is not relevant for the tests.