### PR TITLE
Fix issue with window icons not being displayed

### DIFF
--- a/main/config.js
+++ b/main/config.js
@@ -42,6 +42,7 @@ const packageJson = require('../package.json');
 
 let version;
 let electronRootPath;
+let electronResourcesDir;
 let electronExePath;
 let homeDir;
 let userDataDir;
@@ -84,6 +85,7 @@ let localAppName;
 function init(argv) {
     version = packageJson.version;
     electronRootPath = electronApp.getAppPath();
+    electronResourcesDir = path.join(electronRootPath, 'resources');
     electronExePath = electronApp.getPath('exe');
     homeDir = electronApp.getPath('home');
     userDataDir = electronApp.getPath('userData');
@@ -110,6 +112,7 @@ module.exports = {
     init,
     getVersion: () => version,
     getElectronRootPath: () => electronRootPath,
+    getElectronResourcesDir: () => electronResourcesDir,
     getElectronExePath: () => electronExePath,
     getHomeDir: () => homeDir,
     getUserDataDir: () => userDataDir,

--- a/main/windows.js
+++ b/main/windows.js
@@ -37,6 +37,7 @@
 'use strict';
 
 const electron = require('electron');
+const path = require('path');
 const browser = require('./browser');
 const config = require('./config');
 const settings = require('./settings');
@@ -51,8 +52,8 @@ function openLauncherWindow() {
     } else {
         launcherWindow = browser.createWindow({
             title: `nRF Connect v${config.getVersion()}`,
-            url: `file://${__dirname}/../resources/launcher.html`,
-            icon: `${__dirname}/../resources/nrfconnect.png`,
+            url: `file://${config.getElectronResourcesDir()}/launcher.html`,
+            icon: path.join(config.getElectronResourcesDir(), 'nrfconnect.png'),
             width: 670,
             height: 500,
             center: true,
@@ -76,8 +77,8 @@ function openAppWindow(app) {
     const lastWindowState = settings.loadLastWindow();
     const appWindow = browser.createWindow({
         title: `nRF Connect v${config.getVersion()} - ${app.displayName || app.name}`,
-        url: `file://${__dirname}/../resources/app.html?appPath=${app.path}`,
-        icon: app.iconPath ? app.iconPath : `${__dirname}/../resources/nrfconnect.png`,
+        url: `file://${config.getElectronResourcesDir()}/app.html?appPath=${app.path}`,
+        icon: app.iconPath ? app.iconPath : path.join(config.getElectronResourcesDir(), 'nrfconnect.png'),
         x: lastWindowState.x,
         y: lastWindowState.y,
         width: lastWindowState.width,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.1.0",
+    "version": "2.2.0-alpha.0",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The `__dirname/../` approach apparently did not work when specifying the path to window title icons. The icons were displayed when running the application in development mode, but not when running the packaged version. This is probably related to asar. Using config method for locating the resources directory instead.