### PR TITLE
Upgrade to pc-nrfjprog-js v1.1.0 and command line tools v9.7.1

### DIFF
--- a/build/get-nrfjprog.js
+++ b/build/get-nrfjprog.js
@@ -56,7 +56,7 @@ const DOWNLOAD_DIR = path.join(__dirname, 'nrfjprog');
 
 const PLATFORM_CONFIG = {
     linux: {
-        url: 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfjprog-js/v1.0/nrfjprog/nRF5x-Command-Line-Tools_9_6_0_Linux-x86_64.tar',
+        url: 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfjprog-js/v1.1.0/nrfjprog/nRF5x-Command-Line-Tools_9_7_1_Linux-x86_64.tar',
         destinationFile: path.join(DOWNLOAD_DIR, 'nrfjprog-linux.tar'),
         extractTo: path.join(DOWNLOAD_DIR, 'unpacked'),
         copyFiles: {
@@ -66,7 +66,7 @@ const PLATFORM_CONFIG = {
         },
     },
     darwin: {
-        url: 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfjprog-js/v1.0/nrfjprog/nRF5x-Command-Line-Tools_9_6_0_OSX.tar',
+        url: 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfjprog-js/v1.1.0/nrfjprog/nRF5x-Command-Line-Tools_9_7_1_OSX.tar',
         destinationFile: path.join(DOWNLOAD_DIR, 'nrfjprog-darwin.tar'),
         extractTo: path.join(DOWNLOAD_DIR, 'unpacked'),
         copyFiles: {
@@ -77,7 +77,7 @@ const PLATFORM_CONFIG = {
     },
     win32: {
         // When changing this, remember to also update the nrfjprog version in installer.nsh
-        url: 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfjprog-js/v1.0/nrfjprog/nRF5x-Command-Line-Tools_9_6_0_Installer.exe',
+        url: 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfjprog-js/v1.1.0/nrfjprog/nRF5x-Command-Line-Tools_9_7_1_Installer.exe',
         destinationFile: path.join(DOWNLOAD_DIR, 'nrfjprog-win32.exe'),
     },
 };

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -7,7 +7,7 @@
 
   ; The version of the bundled nRF5x-Command-Line-Tools
   Var /GLOBAL BUNDLED_NRFJPROG_VERSION
-  StrCpy $BUNDLED_NRFJPROG_VERSION "9.6.0"
+  StrCpy $BUNDLED_NRFJPROG_VERSION "9.7.1"
 
   ; Adding Visual C++ Redistributable for Visual Studio 2015
   File "${BUILD_RESOURCES_DIR}\vc_redist_2015.x86.exe"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.2.0-alpha.0",
+    "version": "2.2.0-alpha.1",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "fs-extra": "4.0.1",
         "mustache": "2.3.0",
         "pc-ble-driver-js": "git+https://github.com/NordicSemiconductor/pc-ble-driver-js.git#v2.0.0",
-        "pc-nrfjprog-js": "git+https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#v1.0",
+        "pc-nrfjprog-js": "git+https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#v1.1.0",
         "png2icons": "0.9.1",
         "semver": "5.3.0",
         "serialport": "4.0.7",


### PR DESCRIPTION
Upgrade the pc-nrfjprog-js dependency to v1.1.0. Also upgrading the bundled nRF5x-Command-Line-Tools to v9.7.1.