### PR TITLE
Improve JLink serial number lookup time on Windows

### DIFF
--- a/lib/api/registry/reg.js
+++ b/lib/api/registry/reg.js
@@ -38,7 +38,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 
 function getQueryArgs(keyPath, queryString) {
-    return ['query', keyPath, '/f', queryString, '/s'];
+    return ['query', keyPath, '/f', queryString, '/s', '/t', 'REG_SZ'];
 }
 
 function getRegExePath() {


### PR DESCRIPTION
When finding JLink serial numbers in Windows registry, a recursive search is performed below `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\USB` to find `PortName` and `ParentIdPrefix` values.

By default, the reg.exe command searches all registry types. However, we are only interested in string values (REG_SZ). Adding `/t REG_SZ` to the query command can improve query performance significantly in cases where the user has a lot of non-string entries in the registry.