### PR TITLE
Verify that serial port is not dead when selected

### DIFF
--- a/lib/windows/app/actions/serialPortActions.js
+++ b/lib/windows/app/actions/serialPortActions.js
@@ -73,6 +73,13 @@ function selectorToggleExpandedAction() {
     };
 }
 
+function selectPortAction(port) {
+    return {
+        type: SERIAL_PORT_SELECTED,
+        port,
+    };
+}
+
 function warnAboutMultipleJlinkIds(port, jlinkIds) {
     logger.warn(`Multiple J-Link IDs were found in registry for ${port.comName}: ` +
         `${JSON.stringify(jlinkIds)}. Using ${jlinkIds[0]}.`);
@@ -113,6 +120,25 @@ function decorateWithSerialNumber(ports) {
     return Promise.resolve(ports);
 }
 
+function isPortAvailable(port) {
+    return new Promise((resolve, reject) => {
+        const serialPort = new SerialPort(port.comName, { autoOpen: false });
+        serialPort.open(openErr => {
+            if (openErr) {
+                reject(openErr);
+            } else {
+                serialPort.close(closeErr => {
+                    if (closeErr) {
+                        reject(closeErr);
+                    } else {
+                        resolve();
+                    }
+                });
+            }
+        });
+    });
+}
+
 export function loadPorts() {
     return dispatch => {
         dispatch(loadPortsAction());
@@ -138,9 +164,13 @@ export function toggleSelectorExpanded() {
 }
 
 export function selectPort(port) {
-    return {
-        type: SERIAL_PORT_SELECTED,
-        port,
+    return dispatch => {
+        isPortAvailable(port)
+            .then(() => dispatch(selectPortAction(port)))
+            .catch(error => {
+                logger.error('Unable to open the port. Please power cycle the device and try again.');
+                logger.debug(error.message);
+            });
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.2.1",
+    "version": "2.3.0-alpha.0",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
In some cases, JLink devices stop functioning and become impossible to open. This typically happens when a JLink device has been connected to a Windows PC overnight (related to MSD). The only workaround is to power cycle the device.

When trying to perform operations with nrfjprog when the device is in this state, it will fail silently with no feedback to the user. At the moment, the only reliable way to check if a device is actually available is to try to open it with serialport.