### PR TITLE
Separate data and logging directories for apps

### DIFF
--- a/lib/api/core/index.js
+++ b/lib/api/core/index.js
@@ -34,10 +34,16 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { remote } from 'electron';
-import { getAppDir } from '../../util/apps';
+import {
+    getAppDir,
+    getAppDataDir,
+    getAppLogDir,
+    getUserDataDir,
+} from '../../util/apps';
 
 export default {
     getAppDir,
-    getUserDataDir: () => remote.getGlobal('userDataDir'),
+    getAppDataDir,
+    getAppLogDir,
+    getUserDataDir,
 };

--- a/lib/api/logging/index.js
+++ b/lib/api/logging/index.js
@@ -38,11 +38,8 @@ import winston from 'winston';
 import path from 'path';
 import AppTransport from './appTransport';
 import { createLogBuffer } from './logBuffer';
-import { getUserDataDir } from '../core';
-import { mkdirIfNotExists } from '../../../main/mkdir';
 
 const filePrefix = new Date().toISOString().replace(/:/gi, '_');
-const userDataDir = getUserDataDir();
 let logFilePath;
 
 const isDevelopment = process.env.NODE_ENV === 'development';
@@ -86,32 +83,21 @@ if (isDevelopment && isConsoleAvailable) {
 
 const logger = new winston.Logger({ transports });
 
-logger.addFileTransport = appBaseName => (
-    new Promise(resolve => {
-        const logDir = path.join(userDataDir, appBaseName);
-        mkdirIfNotExists(logDir).then(() => {
-            logFilePath = path.join(logDir, `${filePrefix}-log.txt`);
-            const fileTransport = new winston.transports.File({
-                name: 'file',
-                filename: logFilePath,
-                level: 'debug',
-                json: false,
-                timestamp: () => new Date(),
-                formatter: logFormatter,
-            });
-            logger.add(fileTransport, {}, true);
-        })
-        .then(resolve)
-        .catch(error => {
-            console.error(error);
-            resolve();
-        });
-    })
-);
+logger.addFileTransport = appLogDir => {
+    logFilePath = path.join(appLogDir, `${filePrefix}-log.txt`);
+    const fileTransport = new winston.transports.File({
+        name: 'file',
+        filename: logFilePath,
+        level: 'debug',
+        json: false,
+        timestamp: () => new Date(),
+        formatter: logFormatter,
+    });
+    logger.add(fileTransport, {}, true);
+};
 
 export default {
     logger,
-    userDataDir,
     getLogFilePath: () => logFilePath,
     logBuffer,
 };

--- a/lib/api/logging/index.js
+++ b/lib/api/logging/index.js
@@ -39,10 +39,11 @@ import path from 'path';
 import AppTransport from './appTransport';
 import { createLogBuffer } from './logBuffer';
 import { getUserDataDir } from '../core';
+import { mkdirIfNotExists } from '../../../main/mkdir';
 
 const filePrefix = new Date().toISOString().replace(/:/gi, '_');
 const userDataDir = getUserDataDir();
-const logFilePath = `${userDataDir}${path.sep}${filePrefix}-log.txt`;
+let logFilePath;
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 const isConsoleAvailable = (() => {
@@ -69,18 +70,9 @@ const appTransport = new AppTransport({
     onLogEntry: logBuffer.addEntry,
 });
 
-const fileTransport = new winston.transports.File({
-    name: 'file',
-    filename: logFilePath,
-    level: 'debug',
-    json: false,
-    timestamp: () => new Date(),
-    formatter: logFormatter,
-});
 
 const transports = [
     appTransport,
-    fileTransport,
 ];
 
 if (isDevelopment && isConsoleAvailable) {
@@ -92,9 +84,34 @@ if (isDevelopment && isConsoleAvailable) {
     }));
 }
 
+const logger = new winston.Logger({ transports });
+
+logger.addFileTransport = appPath => (
+    new Promise(resolve => {
+        const logDir = path.join(userDataDir, path.basename(appPath));
+        mkdirIfNotExists(logDir).then(() => {
+            logFilePath = path.join(logDir, `${filePrefix}-log.txt`);
+            const fileTransport = new winston.transports.File({
+                name: 'file',
+                filename: logFilePath,
+                level: 'debug',
+                json: false,
+                timestamp: () => new Date(),
+                formatter: logFormatter,
+            });
+            logger.add(fileTransport, {}, true);
+        })
+        .then(resolve)
+        .catch(error => {
+            console.error(error);
+            resolve();
+        });
+    })
+);
+
 export default {
-    logger: new winston.Logger({ transports }),
+    logger,
     userDataDir,
-    logFilePath,
+    logFilePath: () => logFilePath,
     logBuffer,
 };

--- a/lib/api/logging/index.js
+++ b/lib/api/logging/index.js
@@ -112,6 +112,6 @@ logger.addFileTransport = appPath => (
 export default {
     logger,
     userDataDir,
-    logFilePath: () => logFilePath,
+    getLogFilePath: () => logFilePath,
     logBuffer,
 };

--- a/lib/api/logging/index.js
+++ b/lib/api/logging/index.js
@@ -86,9 +86,9 @@ if (isDevelopment && isConsoleAvailable) {
 
 const logger = new winston.Logger({ transports });
 
-logger.addFileTransport = appPath => (
+logger.addFileTransport = appBaseName => (
     new Promise(resolve => {
-        const logDir = path.join(userDataDir, path.basename(appPath));
+        const logDir = path.join(userDataDir, appBaseName);
         mkdirIfNotExists(logDir).then(() => {
             logFilePath = path.join(logDir, `${filePrefix}-log.txt`);
             const fileTransport = new winston.transports.File({

--- a/lib/util/apps.js
+++ b/lib/util/apps.js
@@ -35,11 +35,20 @@
  */
 
 import React from 'react';
+import path from 'path';
+import { remote } from 'electron';
 import { connect as reduxConnect } from 'react-redux';
 import { loadModule } from './fileUtil';
+import { mkdirIfNotExists } from '../../main/mkdir';
+
+const getUserDataDir = () => remote.getGlobal('userDataDir');
 
 // Directory of the currently loaded app.
 let appDir;
+
+// Directories used by currently loaded app.
+let appDataDir;
+let appLogDir;
 
 // The object exported by the currently loaded app.
 let app;
@@ -48,13 +57,38 @@ let app;
 const decoratedComponents = {};
 
 /**
+ * Initialize app directory paths and ensure that they are created.
+ * Creates:
+ * .../<userDataDir>/<appName>/
+ * .../<userDataDir>/<appName>/logs/
+ *
+ * @param {string} appPath the filesystem path of the app to load.
+ * @returns {Promise} resolved is all directories are present.
+ */
+function initAppDirectories(appPath) {
+    appDir = appPath;
+    const appBaseName = path.basename(appPath);
+    const userDataDir = getUserDataDir();
+    appDataDir = path.join(userDataDir, appBaseName);
+    appLogDir = path.join(appDataDir, 'logs');
+    return new Promise((resolve, reject) => (
+        mkdirIfNotExists(appDataDir).catch(() => {
+            reject(new Error(`Failed to create '${appDataDir}'.`));
+        })
+        .then(() => mkdirIfNotExists(appLogDir).catch(() => {
+            reject(new Error(`Failed to create '${appLogDir}'.`));
+        }))
+        .then(resolve)
+    ));
+}
+
+/**
  * Load an app from the given path.
  *
  * @param {string} appPath the filesystem path of the app to load.
  * @returns {Object} The loaded app object.
  */
 function loadApp(appPath) {
-    appDir = appPath;
     app = loadModule(appPath);
     return app;
 }
@@ -81,6 +115,24 @@ function setApp(appObj) {
  */
 function getAppDir() {
     return appDir;
+}
+
+/**
+ * Get the filesystem path of the data directory of currently loaded app.
+ *
+ * @returns {string|undefined} Absolute path of data directory of the current app.
+ */
+function getAppDataDir() {
+    return appDataDir;
+}
+
+/**
+ * Get the filesystem path of the log directory of currently loaded app.
+ *
+ * @returns {string|undefined} Absolute path of data directory of the current app.
+ */
+function getAppLogDir() {
+    return appLogDir;
 }
 
 /**
@@ -229,11 +281,15 @@ function connect(coreMapStateFn, coreMapDispatchFn, mergeProps, options = {}) {
 }
 
 export default {
+    initAppDirectories,
     loadApp,
     setApp,
     decorateReducer,
     decorate,
     connect,
     getAppDir,
+    getAppDataDir,
+    getAppLogDir,
+    getUserDataDir,
     invokeAppFn,
 };

--- a/lib/windows/app/actions/logActions.js
+++ b/lib/windows/app/actions/logActions.js
@@ -34,7 +34,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { logger, logBuffer, getLogFilePath, userDataDir } from '../../../api/logging';
+import { logger, logBuffer, getLogFilePath } from '../../../api/logging';
+import { getAppDataDir } from '../../../api/core';
 import { openFileInDefaultApplication } from '../../../util/fileUtil';
 
 export const ADD_ENTRIES = 'LOG_ADD_ENTRIES';
@@ -126,7 +127,7 @@ export function clear() {
 
 export function startReading() {
     return dispatch => {
-        logger.info(`Application data folder: ${userDataDir}`);
+        logger.info(`Application data folder: ${getAppDataDir()}`);
         return listenToLogUpdates(dispatch);
     };
 }

--- a/lib/windows/app/actions/logActions.js
+++ b/lib/windows/app/actions/logActions.js
@@ -34,7 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { logger, logBuffer, logFilePath, userDataDir } from '../../../api/logging';
+import { logger, logBuffer, getLogFilePath, userDataDir } from '../../../api/logging';
 import { openFileInDefaultApplication } from '../../../util/fileUtil';
 
 export const ADD_ENTRIES = 'LOG_ADD_ENTRIES';
@@ -105,7 +105,7 @@ function stopLogListener() {
 export function openLogFile() {
     return dispatch => {
         dispatch(openFileAction());
-        openFileInDefaultApplication(logFilePath(), err => {
+        openFileInDefaultApplication(getLogFilePath(), err => {
             if (err) {
                 logger.error(`Unable to open log file: ${err.message}`);
                 dispatch(openFileErrorAction(err.message));

--- a/lib/windows/app/actions/logActions.js
+++ b/lib/windows/app/actions/logActions.js
@@ -105,7 +105,7 @@ function stopLogListener() {
 export function openLogFile() {
     return dispatch => {
         dispatch(openFileAction());
-        openFileInDefaultApplication(logFilePath, err => {
+        openFileInDefaultApplication(logFilePath(), err => {
             if (err) {
                 logger.error(`Unable to open log file: ${err.message}`);
                 dispatch(openFileErrorAction(err.message));

--- a/lib/windows/app/index.js
+++ b/lib/windows/app/index.js
@@ -40,6 +40,7 @@ import React from 'react';
 import * as ReactRedux from 'react-redux';
 import ReactDOM, { render } from 'react-dom';
 import Module from 'module';
+import { basename } from 'path';
 import RootContainer from './containers/RootContainer';
 import configureStore from '../../store/configureStore';
 import { loadApp, invokeAppFn } from '../../util/apps';
@@ -76,8 +77,9 @@ Module._load = function load(path) { // eslint-disable-line no-underscore-dangle
 
 const params = new URL(window.location).searchParams;
 const appPath = params.get('appPath');
+const appBaseName = basename(appPath);
 
-api.core.logger.addFileTransport(appPath).then(() => {
+api.core.logger.addFileTransport(appBaseName).then(() => {
     const app = loadApp(appPath);
 
     const store = configureStore(rootReducer, app);

--- a/lib/windows/app/index.js
+++ b/lib/windows/app/index.js
@@ -76,23 +76,27 @@ Module._load = function load(path) { // eslint-disable-line no-underscore-dangle
 
 const params = new URL(window.location).searchParams;
 const appPath = params.get('appPath');
-const app = loadApp(appPath);
-const store = configureStore(rootReducer, app);
 
-invokeAppFn('onInit', store.dispatch, store.getState);
+api.core.logger.addFileTransport(appPath).then(() => {
+    const app = loadApp(appPath);
 
-const removeLoaderElement = () => {
-    const element = document.getElementById('app-loader');
-    if (element) {
-        element.classList.add('loaded');
-        setTimeout(() => {
-            document.body.removeChild(element);
-        }, 500);
-    }
-};
+    const store = configureStore(rootReducer, app);
 
-const rootElement = React.createElement(RootContainer, { store });
-render(rootElement, document.getElementById('webapp'), () => {
-    removeLoaderElement();
-    invokeAppFn('onReady', store.dispatch, store.getState);
+    invokeAppFn('onInit', store.dispatch, store.getState);
+
+    const removeLoaderElement = () => {
+        const element = document.getElementById('app-loader');
+        if (element) {
+            element.classList.add('loaded');
+            setTimeout(() => {
+                document.body.removeChild(element);
+            }, 500);
+        }
+    };
+
+    const rootElement = React.createElement(RootContainer, { store });
+    render(rootElement, document.getElementById('webapp'), () => {
+        removeLoaderElement();
+        invokeAppFn('onReady', store.dispatch, store.getState);
+    });
 });

--- a/lib/windows/app/index.js
+++ b/lib/windows/app/index.js
@@ -37,13 +37,13 @@
 import 'babel-polyfill';
 
 import React from 'react';
+import electron from 'electron';
 import * as ReactRedux from 'react-redux';
 import ReactDOM, { render } from 'react-dom';
 import Module from 'module';
-import { basename } from 'path';
 import RootContainer from './containers/RootContainer';
 import configureStore from '../../store/configureStore';
-import { loadApp, invokeAppFn } from '../../util/apps';
+import { initAppDirectories, getAppLogDir, loadApp, invokeAppFn } from '../../util/apps';
 import rootReducer from './reducers';
 import api from '../../api';
 import '../../../resources/css/app.less';
@@ -54,7 +54,7 @@ import '../../../resources/css/app.less';
  * Cannot have multiple copies of these loaded at the same time.
  */
 const originalLoad = Module._load;   // eslint-disable-line no-underscore-dangle
-Module._load = function load(path) { // eslint-disable-line no-underscore-dangle
+Module._load = function load(modulePath) { // eslint-disable-line no-underscore-dangle
     const hostedModules = {
         react: React,
         'react-dom': ReactDOM,
@@ -68,8 +68,8 @@ Module._load = function load(path) { // eslint-disable-line no-underscore-dangle
         'nrfconnect/core': api.core,
     };
 
-    if (hostedModules[path]) {
-        return hostedModules[path];
+    if (hostedModules[modulePath]) {
+        return hostedModules[modulePath];
     }
 
     return originalLoad.apply(this, arguments); // eslint-disable-line prefer-rest-params
@@ -77,9 +77,10 @@ Module._load = function load(path) { // eslint-disable-line no-underscore-dangle
 
 const params = new URL(window.location).searchParams;
 const appPath = params.get('appPath');
-const appBaseName = basename(appPath);
 
-api.core.logger.addFileTransport(appBaseName).then(() => {
+initAppDirectories(appPath).then(() => {
+    api.core.logger.addFileTransport(getAppLogDir());
+
     const app = loadApp(appPath);
 
     const store = configureStore(rootReducer, app);
@@ -100,5 +101,12 @@ api.core.logger.addFileTransport(appBaseName).then(() => {
     render(rootElement, document.getElementById('webapp'), () => {
         removeLoaderElement();
         invokeAppFn('onReady', store.dispatch, store.getState);
+    });
+})
+.catch(error => {
+    console.error(error);
+    electron.remote.dialog.showMessageBox({
+        type: 'error',
+        message: error.message,
     });
 });

--- a/main/fileUtil.js
+++ b/main/fileUtil.js
@@ -44,6 +44,7 @@ const fse = require('fs-extra');
 const path = require('path');
 const targz = require('targz');
 const chmodr = require('chmodr');
+const { mkdir, mkdirIfNotExists } = require('./mkdir');
 
 /**
  * Open the given file path and return its string contents.
@@ -278,30 +279,6 @@ function getNameFromNpmPackage(tgzFile) {
         return fileName.substring(0, lastDash);
     }
     return null;
-}
-
-function mkdir(dirPath) {
-    return new Promise((resolve, reject) => {
-        fs.mkdir(dirPath, 0o775, error => {
-            if (error) {
-                reject(new Error(`Unable to create ${dirPath}: ${error.message}`));
-            } else {
-                resolve();
-            }
-        });
-    });
-}
-
-function mkdirIfNotExists(dirPath) {
-    return new Promise((resolve, reject) => {
-        fs.stat(dirPath, error => {
-            if (error) {
-                mkdir(dirPath).then(resolve).catch(reject);
-            } else {
-                resolve();
-            }
-        });
-    });
 }
 
 function createTextFile(filePath, text) {

--- a/main/mkdir.js
+++ b/main/mkdir.js
@@ -1,0 +1,68 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const fs = require('fs');
+
+function mkdir(dirPath) {
+    return new Promise((resolve, reject) => {
+        fs.mkdir(dirPath, 0o775, error => {
+            if (error) {
+                reject(new Error(`Unable to create ${dirPath}: ${error.message}`));
+            } else {
+                resolve();
+            }
+        });
+    });
+}
+
+function mkdirIfNotExists(dirPath) {
+    return new Promise((resolve, reject) => {
+        fs.stat(dirPath, error => {
+            if (error) {
+                mkdir(dirPath).then(resolve).catch(reject);
+            } else {
+                resolve();
+            }
+        });
+    });
+}
+
+module.exports = {
+    mkdir,
+    mkdirIfNotExists,
+};


### PR DESCRIPTION
Basename of appPath is used to create separate directories under so far common logdir in order to separate the similarly named logfiles.

Update:
The context of this PR changed slightly, for apps, the core initilizes
`...<userDataDir>/<appName>` as *appDataDir* and `...<userDataDir>/<appName>/logs` as *appLogDir*. We decided separate *config* directory is not needed, so that is now skipped.