### PR TITLE
Fix side panel resize issue

### DIFF
--- a/resources/css/app.less
+++ b/resources/css/app.less
@@ -25,6 +25,7 @@ html, body, #webapp {
         flex: 1;
         display: flex;
         flex-flow: column;
+        min-width: 0;
 
         // main view
         > div:nth-child(1) {


### PR DESCRIPTION
When there is some wide content in the main view, the side panel is pushed to the right and may end up being too narrow or hidden. Applying this `min-width: 0` flexbox trick that @bencefr used for one of the apps. This keeps the side panel visible, and adjusts the size of the main view instead. If the contents of the main view cannot be made narrower, f.ex. in the BLE app if there are many connections, then a horizontal scrollbar is shown in the main view.

For more info on this approach, see: https://css-tricks.com/flexbox-truncated-text/

Before fix:

![image](https://user-images.githubusercontent.com/461755/32727292-57ff12ae-c87c-11e7-9aea-4adacf74cf1f.png)

After fix:

![image](https://user-images.githubusercontent.com/461755/32727310-690c825c-c87c-11e7-9d6b-71e983397551.png)