### PR TITLE
Added confirmation and removal of old local app upon extract

### DIFF
--- a/main/apps.js
+++ b/main/apps.js
@@ -118,7 +118,7 @@ function generateUpdatesJsonFile() {
  *
  * @param {string} tgzFilePath Path to the tgz file to install.
  * @param {string} appPath Path of the existing app directory.
- * @returns {Promise} promise that resolves when existing app has been removed.
+ * @returns {Promise} promise that resolves when all is done.
  */
 function confirmAndRemoveOldLocalApp(tgzFilePath, appPath) {
     return new Promise(resolve => {


### PR DESCRIPTION
In case a new tgz package is found in local app directory while the same app is already installed, the user is now offered that the old app can be removed, thus avoiding required user action outside of the application.