### PR TITLE
Use pc-ble-driver-js from npm with precompiled binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.3.0-alpha.0",
+    "version": "2.3.0-alpha.1",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "electron-updater": "2.0.0",
         "fs-extra": "4.0.1",
         "mustache": "2.3.0",
-        "pc-ble-driver-js": "git+https://github.com/NordicSemiconductor/pc-ble-driver-js.git#v2.1.1",
+        "pc-ble-driver-js": "2.2.2",
         "pc-nrfjprog-js": "git+https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#v1.1.0",
         "png2icons": "0.9.1",
         "semver": "5.3.0",


### PR DESCRIPTION
Now that pc-ble-driver-js has been published to npm and includes precompiled binaries, this project should install a lot faster.

Also good to use the opportunity to test the precompiled binaries during development some time before the next pc-nrfconnect-core release.