### PR TITLE
Handle edge cases in J-Link serial number lookup

### DIFF
--- a/lib/api/registry/index.js
+++ b/lib/api/registry/index.js
@@ -59,8 +59,8 @@ import { findParentIdPrefixes, findJlinkIds } from './jlink';
 // comName. This can happen if the COM port number on the system goes beyond
 // COM256, or if the port numbering is manually reset. In these cases the
 // registry may contain outdated relations between comNames and J-Link IDs,
-// and we do not know which one is correct. We return all IDs found so that
-// the application can display a warning. The largest ID is returned first.
+// and we do not know which one is correct. We return all IDs found and
+// leave it up to the caller to pick the right one.
 
 function findJlinkIdsFromRegistry(comName) {
     return findParentIdPrefixes(comName)

--- a/lib/api/registry/reg.js
+++ b/lib/api/registry/reg.js
@@ -57,10 +57,13 @@ function regCmd(args) {
 
         proc.on('close', code => {
             if (code !== 0) {
-                reject(`Error when calling reg.exe: ${buffer}`);
-            } else {
-                resolve(buffer);
+                // The reg.exe command exits with code 1 if a query returns
+                // zero results. However, this could also indicate that there
+                // is an error, so logging it for traceability reasons.
+                console.log(`The reg.exe command exited with code ${code}. ` +
+                    `Arguments: ${JSON.stringify(args)}. Output: ${buffer}.`);
             }
+            resolve(buffer);
         });
 
         proc.stdout.on('data', data => {

--- a/lib/windows/app/actions/serialPortActions.js
+++ b/lib/windows/app/actions/serialPortActions.js
@@ -116,8 +116,10 @@ function getPortWithSerialNumber(port) {
                 if (jlinkIds.length === 1) {
                     return jlinkIds[0];
                 } else if (jlinkIds.length > 1) {
-                    // When querying the registry for J-Link IDs we may receive
-                    // multiple IDs. In that case, use the one that is connected.
+                    logger.warn(`Found multiple J-Link IDs in registry for ${port.comName}: ` +
+                        `${JSON.stringify(jlinkIds)}. This may indicate that your registry ` +
+                        'contains invalid data. Using nrfjprog to detect which one is ' +
+                        'connected.');
                     return findConnectedJlinkId(jlinkIds);
                 }
                 throw new Error('No J-Link ID found.');

--- a/lib/windows/app/actions/serialPortActions.js
+++ b/lib/windows/app/actions/serialPortActions.js
@@ -35,6 +35,7 @@
  */
 
 import SerialPort from 'serialport';
+import nrfjprogjs from 'pc-nrfjprog-js';
 import { findJlinkIds } from '../../../api/registry';
 import { logger } from '../../../api/logging';
 
@@ -80,34 +81,67 @@ function selectPortAction(port) {
     };
 }
 
-function warnAboutMultipleJlinkIds(port, jlinkIds) {
-    logger.warn(`Multiple J-Link IDs were found in registry for ${port.comName}: ` +
-        `${JSON.stringify(jlinkIds)}. Using ${jlinkIds[0]}.`);
-}
-
-function warnAboutNoJlinkId(port) {
-    logger.warn(`No J-Link ID was found in registry for ${port.comName}.`);
-}
-
-function getPortWithSerialNumber(port) {
-    return findJlinkIds(port.comName)
-        .then(jlinkIds => {
-            if (jlinkIds.length > 1) {
-                warnAboutMultipleJlinkIds(port, jlinkIds);
-            } else if (jlinkIds.length === 0) {
-                warnAboutNoJlinkId(port);
-                return port;
+function getConnectedDevices() {
+    return new Promise((resolve, reject) => {
+        nrfjprogjs.getConnectedDevices((error, devices) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(devices);
             }
-            return Object.assign({}, port, {
-                serialNumber: jlinkIds[0],
+        });
+    });
+}
+
+function findConnectedJlinkId(jlinkIds) {
+    return getConnectedDevices()
+        .then(devices => {
+            const connectedJlinkId = jlinkIds.find(jlinkId => {
+                const jlinkIdNumber = parseInt(jlinkId, 10);
+                const device = devices.find(dev => dev.serialNumber === jlinkIdNumber);
+                return !!device;
             });
+            if (!connectedJlinkId) {
+                throw new Error(`Got multiple J-Link IDs (${JSON.stringify(jlinkIds)}), ` +
+                    'but none are connected.');
+            }
+            return connectedJlinkId;
         });
 }
 
+function getPortWithSerialNumber(port) {
+    return new Promise(resolve => {
+        findJlinkIds(port.comName)
+            .then(jlinkIds => {
+                if (jlinkIds.length === 1) {
+                    return jlinkIds[0];
+                } else if (jlinkIds.length > 1) {
+                    // When querying the registry for J-Link IDs we may receive
+                    // multiple IDs. In that case, use the one that is connected.
+                    return findConnectedJlinkId(jlinkIds);
+                }
+                throw new Error('No J-Link ID found.');
+            })
+            .then(jlinkId => {
+                resolve(Object.assign({}, port, {
+                    serialNumber: jlinkId,
+                }));
+            })
+            .catch(error => {
+                logger.warn(`J-Link serial number lookup failed for ${port.comName}: ` +
+                    `${error.message}`);
+                resolve(port);
+            });
+    });
+}
+
 function getPortsWithSerialNumber(ports) {
-    const promises = ports.map(port => (
-        port.vendorId === SEGGER_VENDOR_ID ? getPortWithSerialNumber(port) : port),
-    );
+    const promises = ports.map(port => {
+        if (port.vendorId === SEGGER_VENDOR_ID) {
+            return getPortWithSerialNumber(port);
+        }
+        return Promise.resolve(port);
+    });
     return Promise.all(promises);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.3.0-alpha.1",
+    "version": "2.3.0-alpha.2",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
On Windows, we perform a lookup in the registry to find J-Link serial numbers for COM ports. There are some weaknesses with this approach as described in [lib/api/registry/index.js](https://github.com/NordicSemiconductor/pc-nrfconnect-core/blob/4b33f532d157e47ccae26b60a67b89d6b1d7ff22/lib/api/registry/index.js). Multiple serial numbers may be returned, and we do not know which one to use. Up until now, we have just picked the highest number.

When getting multiple serial numbers, we now invoke pc-nrfjprog-js to detect which one is actually connected. Calling pc-nrfjprog-js will slow down listing of the serial ports, so we only do it when required.