### PR TITLE
Further improve serial number lookup routine on Windows

### DIFF
--- a/lib/api/jlink/__tests__/jlinkFacade-test.js
+++ b/lib/api/jlink/__tests__/jlinkFacade-test.js
@@ -75,9 +75,7 @@ describe('JlinkFacade', () => {
     it('returns empty map if comName is given, and two serial numbers found in registry, but none are connected', () => {
         const facade = new JlinkFacade();
         facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000234567890']);
-        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [{
-            serialNumber: 345678901,
-        }]);
+        facade.nrfjprogjs.getSerialNumbers = callback => callback(null, [345678901]);
         return facade.getSerialNumberMap(['COM1'])
             .then(map => expect(map.size).toEqual(0));
     });
@@ -85,9 +83,7 @@ describe('JlinkFacade', () => {
     it('emits warning if comName is given, and two serial numbers found in registry, but none are connected', () => {
         const facade = new JlinkFacade();
         facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000234567890']);
-        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [{
-            serialNumber: 345678901,
-        }]);
+        facade.nrfjprogjs.getSerialNumbers = callback => callback(null, [345678901]);
         let warningMessage;
         facade.on('warn', message => {
             warningMessage = message;
@@ -102,7 +98,7 @@ describe('JlinkFacade', () => {
     it('rejects if comName is given, and two serial numbers found in registry, but connected devices lookup fails', () => {
         const facade = new JlinkFacade();
         facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000234567890']);
-        facade.nrfjprogjs.getConnectedDevices = callback => callback(new Error('Lookup failed'));
+        facade.nrfjprogjs.getSerialNumbers = callback => callback(new Error('Lookup failed'));
         return facade.getSerialNumberMap(['COM1'])
             .catch(error => expect(error.message).toContain('Lookup failed'));
     });
@@ -133,20 +129,17 @@ describe('JlinkFacade', () => {
     it('does not call nrfjprogjs if comName is given, and one serial number found in registry', () => {
         const facade = new JlinkFacade();
         facade.registry.findJlinkIds = () => Promise.resolve(['000123456789']);
-        facade.nrfjprogjs.getConnectedDevices = jest.fn();
+        facade.nrfjprogjs.getSerialNumbers = jest.fn();
         return facade.getSerialNumberMap(['COM1'])
             .then(() => {
-                expect(facade.nrfjprogjs.getConnectedDevices).not.toHaveBeenCalled();
+                expect(facade.nrfjprogjs.getSerialNumbers).not.toHaveBeenCalled();
             });
     });
 
     it('returns map with serial number if comName is given, and two serial numbers found in registry, and one is connected', () => {
         const facade = new JlinkFacade();
         facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000987654321']);
-        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [
-            { serialNumber: 234567890 },
-            { serialNumber: 123456789 },
-        ]);
+        facade.nrfjprogjs.getSerialNumbers = callback => callback(null, [234567890, 123456789]);
         return facade.getSerialNumberMap(['COM1'])
             .then(map => {
                 expect(map.size).toEqual(1);
@@ -157,10 +150,7 @@ describe('JlinkFacade', () => {
     it('emits warning if comName is given, and two serial numbers found in registry, and one is connected', () => {
         const facade = new JlinkFacade();
         facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000987654321']);
-        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [
-            { serialNumber: 234567890 },
-            { serialNumber: 123456789 },
-        ]);
+        facade.nrfjprogjs.getSerialNumbers = callback => callback(null, [234567890, 123456789]);
         let warningMessage;
         facade.on('warn', message => {
             warningMessage = message;
@@ -181,10 +171,10 @@ describe('JlinkFacade', () => {
             };
             return Promise.resolve(serialNumbers[comName]);
         };
-        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [
-            { serialNumber: 345678901 },
-            { serialNumber: 234567890 },
-            { serialNumber: 123456789 },
+        facade.nrfjprogjs.getSerialNumbers = callback => callback(null, [
+            345678901,
+            234567890,
+            123456789,
         ]);
         return facade.getSerialNumberMap(['COM1', 'COM2'])
             .then(map => {

--- a/lib/api/jlink/__tests__/jlinkFacade-test.js
+++ b/lib/api/jlink/__tests__/jlinkFacade-test.js
@@ -1,0 +1,196 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import JlinkFacade from '../jlinkFacade';
+
+describe('JlinkFacade', () => {
+    it('returns empty map if empty list of comNames is given', () => {
+        const facade = new JlinkFacade();
+        return facade.getSerialNumberMap([])
+            .then(map => expect(map.size).toEqual(0));
+    });
+
+    it('returns empty map if comName is given, but no serial numbers found for the comName in registry', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve([]);
+        return facade.getSerialNumberMap(['COM1'])
+            .then(map => expect(map.size).toEqual(0));
+    });
+
+    it('emits warning if comName is given, but no serial numbers found for the comName in registry', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve([]);
+        let warningMessage;
+        facade.on('warn', message => {
+            warningMessage = message;
+        });
+        return facade.getSerialNumberMap(['COM1'])
+            .then(() => expect(warningMessage).toContain('Could not find serial number for COM1'));
+    });
+
+    it('emits warning if comName is given, but registry lookup fails', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.reject(new Error('Lookup failed'));
+        let warningMessage;
+        facade.on('warn', message => {
+            warningMessage = message;
+        });
+        return facade.getSerialNumberMap(['COM1'])
+            .then(() => expect(warningMessage).toContain('Lookup failed'));
+    });
+
+    it('returns empty map if comName is given, and two serial numbers found in registry, but none are connected', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000234567890']);
+        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [{
+            serialNumber: 345678901,
+        }]);
+        return facade.getSerialNumberMap(['COM1'])
+            .then(map => expect(map.size).toEqual(0));
+    });
+
+    it('emits warning if comName is given, and two serial numbers found in registry, but none are connected', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000234567890']);
+        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [{
+            serialNumber: 345678901,
+        }]);
+        let warningMessage;
+        facade.on('warn', message => {
+            warningMessage = message;
+        });
+        return facade.getSerialNumberMap(['COM1'])
+            .then(() => {
+                expect(warningMessage).toEqual('Found serial numbers 000123456789, 000234567890 for ' +
+                    'COM1 in registry, but none of these are connected. Unable to identify serial number.');
+            });
+    });
+
+    it('rejects if comName is given, and two serial numbers found in registry, but connected devices lookup fails', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000234567890']);
+        facade.nrfjprogjs.getConnectedDevices = callback => callback(new Error('Lookup failed'));
+        return facade.getSerialNumberMap(['COM1'])
+            .catch(error => expect(error.message).toContain('Lookup failed'));
+    });
+
+    it('returns map with serial number if comName is given, and one serial number found in registry', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve(['000123456789']);
+        return facade.getSerialNumberMap(['COM1'])
+            .then(map => {
+                expect(map.size).toEqual(1);
+                expect(map.get('COM1')).toEqual('000123456789');
+            });
+    });
+
+    it('does not emit warning if comName is given, and one serial number found in registry', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve(['000123456789']);
+        let warningMessage;
+        facade.on('warn', message => {
+            warningMessage = message;
+        });
+        return facade.getSerialNumberMap(['COM1'])
+            .then(() => {
+                expect(warningMessage).not.toBeDefined();
+            });
+    });
+
+    it('does not call nrfjprogjs if comName is given, and one serial number found in registry', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve(['000123456789']);
+        facade.nrfjprogjs.getConnectedDevices = jest.fn();
+        return facade.getSerialNumberMap(['COM1'])
+            .then(() => {
+                expect(facade.nrfjprogjs.getConnectedDevices).not.toHaveBeenCalled();
+            });
+    });
+
+    it('returns map with serial number if comName is given, and two serial numbers found in registry, and one is connected', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000987654321']);
+        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [
+            { serialNumber: 234567890 },
+            { serialNumber: 123456789 },
+        ]);
+        return facade.getSerialNumberMap(['COM1'])
+            .then(map => {
+                expect(map.size).toEqual(1);
+                expect(map.get('COM1')).toEqual('000123456789');
+            });
+    });
+
+    it('emits warning if comName is given, and two serial numbers found in registry, and one is connected', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = () => Promise.resolve(['000123456789', '000987654321']);
+        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [
+            { serialNumber: 234567890 },
+            { serialNumber: 123456789 },
+        ]);
+        let warningMessage;
+        facade.on('warn', message => {
+            warningMessage = message;
+        });
+        return facade.getSerialNumberMap(['COM1'])
+            .then(() => {
+                expect(warningMessage).toEqual('Found serial numbers 000123456789, 000987654321 for ' +
+                    'COM1 in registry. 000123456789 is connected, so using that.');
+            });
+    });
+
+    it('returns map with serial numbers if multiple comNames are given, and two serial numbers found in registry for each, and one is connected for each', () => {
+        const facade = new JlinkFacade();
+        facade.registry.findJlinkIds = comName => {
+            const serialNumbers = {
+                COM1: ['000123456789', '000987654321'],
+                COM2: ['000456789012', '000345678901'],
+            };
+            return Promise.resolve(serialNumbers[comName]);
+        };
+        facade.nrfjprogjs.getConnectedDevices = callback => callback(null, [
+            { serialNumber: 345678901 },
+            { serialNumber: 234567890 },
+            { serialNumber: 123456789 },
+        ]);
+        return facade.getSerialNumberMap(['COM1', 'COM2'])
+            .then(map => {
+                expect(map.size).toEqual(2);
+                expect(map.get('COM1')).toEqual('000123456789');
+                expect(map.get('COM2')).toEqual('000345678901');
+            });
+    });
+});

--- a/lib/api/jlink/jlinkFacade.js
+++ b/lib/api/jlink/jlinkFacade.js
@@ -1,0 +1,167 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import EventEmitter from 'events';
+import nrfjprogjs from 'pc-nrfjprog-js';
+import registry from '../registry';
+
+/**
+ * Combines Windows registry lookup and connected serial numbers from nrfjprog
+ * to uniquely identify serial numbers for SEGGER J-Link devices.
+ *
+ * On Windows, there are no APIs that give us the COM name <-> serial number
+ * relation. We have to do a registry lookup to find J-Link IDs for COM names.
+ * Unfortunately, the registry may contain multiple serial numbers for the same
+ * COM name. This is because COM names may be reused over the course of time,
+ * and then the registry will contain old numbers in addition to the current
+ * serial number.
+ *
+ * When we are not able to identify the serial number only from the registry
+ * alone, we filter out the serial numbers that are not in the list of connected
+ * serial numbers from nrfjprog. The nrfjprog lookup is slow, so we only use it
+ * when we have to.
+ */
+export default class JlinkFacade extends EventEmitter {
+
+    constructor() {
+        super();
+
+        // These may be monkey patched by unit tests.
+        this.registry = registry;
+        this.nrfjprogjs = nrfjprogjs;
+    }
+
+    emitWarning(message) {
+        /**
+         * Fired when not able to uniquely identify a serial number in registry.
+         *
+         * @event JlinkFacade#warn
+         * @type {string}
+         */
+        this.emit('warn', message);
+    }
+
+    /**
+     * Get a Map containing COM port name as key and serial number as value. The serial
+     * numbers are retrieved from the Windows registry. Using nrfjprogjs if the
+     * serial number cannot be uniquely identified from registry.
+     *
+     * @param {string[]} comNames The com port names to look up serial numbers for.
+     * @fires JlinkFacade#warn
+     * @returns {Promise} Promise that resolves with a Map instance.
+     */
+    getSerialNumberMap(comNames) {
+        const promises = comNames.map(comName => (
+            new Promise(resolve => {
+                this.registry.findJlinkIds(comName)
+                    .then(serialNumbers => resolve({ comName, serialNumbers }))
+                    .catch(error => {
+                        // Catching and emitting here, as we don't want one bad device
+                        // to block all other lookups.
+                        this.emitWarning(`Unable to read serial number for ${comName} ` +
+                            `from registry: ${error.message}`);
+                        resolve();
+                    });
+            })
+        ));
+        return Promise.all(promises)
+            .then(results => results.filter(result => !!result))
+            .then(results => {
+                const hasMultipleSnrs = results.some(result => result.serialNumbers.length > 1);
+                if (hasMultipleSnrs) {
+                    return this.getConnectedSerialNumbers()
+                        .then(connectedSnrs => (
+                            this.createMap(results, connectedSnrs)
+                        ));
+                }
+                return this.createMap(results);
+            });
+    }
+
+    /**
+     * Get an array of all serial numbers that are currently connected.
+     *
+     * @returns {Promise} Promise that resolves with an array of serial numbers (integers).
+     */
+    getConnectedSerialNumbers() {
+        return new Promise((resolve, reject) => {
+            this.nrfjprogjs.getConnectedDevices((error, devices) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(devices.map(device => device.serialNumber));
+                }
+            });
+        });
+    }
+
+    /**
+     * Create a Map instance from the results array. If multiple serial numbers exist for
+     * one COM name, and connectedSerialNumbers are given, then referring to the list
+     * of connected serial numbers to find which one to use.
+     *
+     * @param {Array<Object>} results Array of objects, with each object having a
+     *     comName (string) and serialNumbers (string[]) property.
+     * @param {number[]} [connectedSerialNumbers] Serial numbers that are connected.
+     * @returns {Map<string,string>} Map with COM name as key and serial number as value.
+     */
+    createMap(results, connectedSerialNumbers) {
+        const map = new Map();
+        results.forEach(result => {
+            const { comName, serialNumbers } = result;
+            if (serialNumbers.length === 1) {
+                map.set(comName, serialNumbers[0]);
+            } else if (serialNumbers.length > 1 && connectedSerialNumbers) {
+                const serialNumber = serialNumbers.find(snr => (
+                    connectedSerialNumbers.includes(parseInt(snr, 10))
+                ));
+                if (serialNumber) {
+                    this.emitWarning(`Found serial numbers ${serialNumbers.join(', ')} ` +
+                        `for ${comName} in registry. ${serialNumber} is connected, so ` +
+                        'using that.');
+                    map.set(comName, serialNumber);
+                } else {
+                    this.emitWarning(`Found serial numbers ${serialNumbers.join(', ')} ` +
+                        `for ${comName} in registry, but none of these are connected. ` +
+                        'Unable to identify serial number.');
+                }
+            } else {
+                this.emitWarning(`Could not find serial number for ${comName} in registry.`);
+            }
+        });
+        return map;
+    }
+}

--- a/lib/api/jlink/jlinkFacade.js
+++ b/lib/api/jlink/jlinkFacade.js
@@ -51,8 +51,8 @@ import registry from '../registry';
  *
  * When we are not able to identify the serial number only from the registry
  * alone, we filter out the serial numbers that are not in the list of connected
- * serial numbers from nrfjprog. The nrfjprog lookup is slow, so we only use it
- * when we have to.
+ * serial numbers from nrfjprog. Only doing the nrfjprog lookup if required,
+ * in order to make it as fast as possible.
  */
 export default class JlinkFacade extends EventEmitter {
 
@@ -118,11 +118,11 @@ export default class JlinkFacade extends EventEmitter {
      */
     getConnectedSerialNumbers() {
         return new Promise((resolve, reject) => {
-            this.nrfjprogjs.getConnectedDevices((error, devices) => {
+            this.nrfjprogjs.getSerialNumbers((error, serialNumbers) => {
                 if (error) {
                     reject(error);
                 } else {
-                    resolve(devices.map(device => device.serialNumber));
+                    resolve(serialNumbers);
                 }
             });
         });

--- a/lib/windows/app/actions/serialPortActions.js
+++ b/lib/windows/app/actions/serialPortActions.js
@@ -35,8 +35,7 @@
  */
 
 import SerialPort from 'serialport';
-import nrfjprogjs from 'pc-nrfjprog-js';
-import { findJlinkIds } from '../../../api/registry';
+import JlinkFacade from '../../../api/jlink/jlinkFacade';
 import { logger } from '../../../api/logging';
 
 export const SERIAL_PORTS_LOAD = 'SERIAL_PORTS_LOAD';
@@ -81,77 +80,36 @@ function selectPortAction(port) {
     };
 }
 
-function getConnectedDevices() {
+function getSeggerComNames(ports) {
+    return ports.filter(port => port.vendorId === SEGGER_VENDOR_ID)
+        .map(port => port.comName);
+}
+
+function getPortsWithSerialNumberOnWindows(ports) {
     return new Promise((resolve, reject) => {
-        nrfjprogjs.getConnectedDevices((error, devices) => {
-            if (error) {
-                reject(error);
-            } else {
-                resolve(devices);
-            }
-        });
-    });
-}
-
-function findConnectedJlinkId(jlinkIds) {
-    return getConnectedDevices()
-        .then(devices => {
-            const connectedJlinkId = jlinkIds.find(jlinkId => {
-                const jlinkIdNumber = parseInt(jlinkId, 10);
-                const device = devices.find(dev => dev.serialNumber === jlinkIdNumber);
-                return !!device;
-            });
-            if (!connectedJlinkId) {
-                throw new Error(`Got multiple J-Link IDs (${JSON.stringify(jlinkIds)}), ` +
-                    'but none are connected.');
-            }
-            return connectedJlinkId;
-        });
-}
-
-function getPortWithSerialNumber(port) {
-    return new Promise(resolve => {
-        findJlinkIds(port.comName)
-            .then(jlinkIds => {
-                if (jlinkIds.length === 1) {
-                    return jlinkIds[0];
-                } else if (jlinkIds.length > 1) {
-                    logger.warn(`Found multiple J-Link IDs in registry for ${port.comName}: ` +
-                        `${JSON.stringify(jlinkIds)}. This may indicate that your registry ` +
-                        'contains invalid data. Using nrfjprog to detect which one is ' +
-                        'connected.');
-                    return findConnectedJlinkId(jlinkIds);
-                }
-                throw new Error('No J-Link ID found.');
-            })
-            .then(jlinkId => {
-                resolve(Object.assign({}, port, {
-                    serialNumber: jlinkId,
-                }));
+        const decoratedPorts = ports.slice();
+        const seggerComNames = getSeggerComNames(ports);
+        const facade = new JlinkFacade();
+        facade.on('warn', logger.warn);
+        facade.getSerialNumberMap(seggerComNames)
+            .then(map => {
+                map.forEach((serialNumber, comName) => {
+                    const port = decoratedPorts.find(p => p.comName === comName);
+                    port.serialNumber = serialNumber;
+                });
+                resolve(decoratedPorts);
             })
             .catch(error => {
-                logger.warn(`J-Link serial number lookup failed for ${port.comName}: ` +
-                    `${error.message}`);
-                resolve(port);
+                reject(error);
             });
     });
-}
-
-function getPortsWithSerialNumber(ports) {
-    const promises = ports.map(port => {
-        if (port.vendorId === SEGGER_VENDOR_ID) {
-            return getPortWithSerialNumber(port);
-        }
-        return Promise.resolve(port);
-    });
-    return Promise.all(promises);
 }
 
 function decorateWithSerialNumber(ports) {
     // On Linux and macOS, the serial number is discovered by the serialport library.
     // On Windows, we have to query the registry to find the serial number.
     if (process.platform === 'win32') {
-        return getPortsWithSerialNumber(ports);
+        return getPortsWithSerialNumberOnWindows(ports);
     }
     return Promise.resolve(ports);
 }
@@ -183,7 +141,8 @@ export function loadPorts() {
                 dispatch(loadPortsErrorAction(err.message));
             } else {
                 decorateWithSerialNumber(ports)
-                    .then(finalPorts => dispatch(loadPortsSuccessAction(finalPorts)));
+                    .then(finalPorts => dispatch(loadPortsSuccessAction(finalPorts)))
+                    .catch(error => loadPortsErrorAction(error.message));
             }
         });
     };

--- a/mocks/nrfjprogjsMock.js
+++ b/mocks/nrfjprogjsMock.js
@@ -1,0 +1,3 @@
+// Allows jest to test files that import pc-nrfjprog-js.
+
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.3.0-alpha.2",
+    "version": "2.3.0-alpha.3",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "fs-extra": "4.0.1",
         "mustache": "2.3.0",
         "pc-ble-driver-js": "2.2.2",
-        "pc-nrfjprog-js": "git+https://github.com/NordicSemiconductor/pc-nrfjprog-js.git#v1.1.0",
+        "pc-nrfjprog-js": "1.2.0",
         "png2icons": "0.9.1",
         "semver": "5.3.0",
         "serialport": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
         "moduleNameMapper": {
             "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$": "<rootDir>/mocks/fileMock.js",
             "\\.(css|less)$": "<rootDir>/mocks/styleMock.js",
-            "\\.(js|jsx)$": "<rootDir>/mocks/electronMock.js"
+            "electron": "<rootDir>/mocks/electronMock.js",
+            "pc-nrfjprog-js": "<rootDir>/mocks/nrfjprogjsMock.js"
         }
     }
 }


### PR DESCRIPTION
In #145, we added a mechanism for querying pc-nrfjprog-js when multiple serial numbers exist for a COM port in Windows registry. This worked fine as long as there was only one COM port that had multiple serial numbers. However, when multiple ports have multiple serial numbers, pc-nrfjprog-js was called multiple times in parallel. This crashed the application, as pc-nrfjprog-js does not support multiple operations in parallel.

The logic around this started to get a bit complicated, so I have now extracted the serial number lookup routine for Windows into a JlinkFacade. This combines registry lookup with connected devices from pc-nrfjprog-js to identify which serial number to use.