### PR TITLE
Make app shortcuts work when using AppImage

### DIFF
--- a/main/config.js
+++ b/main/config.js
@@ -86,7 +86,7 @@ function init(argv) {
     version = packageJson.version;
     electronRootPath = electronApp.getAppPath();
     electronResourcesDir = path.join(electronRootPath, 'resources');
-    electronExePath = electronApp.getPath('exe');
+    electronExePath = process.env.APPIMAGE || electronApp.getPath('exe');
     homeDir = electronApp.getPath('home');
     userDataDir = electronApp.getPath('userData');
     desktopDir = electronApp.getPath('desktop');


### PR DESCRIPTION
When the application is started as an AppImage, it mounts the image in /tmp and executes the application from there. The `electronApp.getPath('exe')` then returns the path to the executable
inside the mounted image. This is just a temporary path, so when the application is restarted, the path to the executable in /tmp will be different.

We need a more reliable path to the executable, as this is the path that we refer to when creating app shortcuts. When being run as an AppImage, the application will have an `APPIMAGE` environment variable that points to the path of the AppImage file. Using that as executable path if it is set, so that
shortcuts point to the right place.