### PR TITLE
Upgrade to electron 1.6.16

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
-target = 1.6.7
+target = 1.6.16
 disturl = https://atom.io/download/atom-shell

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "asar": "0.13.0",
         "babel-polyfill": "6.23.0",
         "bootstrap": "3.3.7",
-        "electron": "1.6.7",
+        "electron": "1.6.16",
         "electron-builder": "19.53.6",
         "electron-is-dev": "0.1.2",
         "moment": "2.18.1",


### PR DESCRIPTION
Upgrading electron to get the latest patches for 1.6.

We should also consider upgrading to the latest minor version, but while the electron API is following semver (no breaking changes before 2.0), the bundled Node.js and Chrome versions may introduce breaking changes. Also, upgrading to the latest minor would require publishing new binaries for pc-ble-driver-js and pc-nrfjprog-js.