### PR TITLE
Show link to releases when asking for core update

### DIFF
--- a/lib/components/ConfirmationDialog.jsx
+++ b/lib/components/ConfirmationDialog.jsx
@@ -67,27 +67,25 @@ const ConfirmationDialog = ({
     okButtonText,
     cancelButtonText,
 }) => (
-    <div>
-        <Modal show={isVisible} onHide={onCancel} backdrop={isInProgress ? 'static' : false}>
-            <ModalHeader closeButton={!isInProgress}>
-                <ModalTitle>{title}</ModalTitle>
-            </ModalHeader>
-            <ModalBody>
-                { children || <p>{ text }</p> }
-            </ModalBody>
-            <ModalFooter>
-                { isInProgress ? <Spinner /> : null }
-                &nbsp;
-                <Button onClick={onOk} disabled={isInProgress}>{okButtonText}</Button>
-                {
-                    onCancel &&
-                    <Button onClick={onCancel} disabled={isInProgress}>
-                        {cancelButtonText}
-                    </Button>
-                }
-            </ModalFooter>
-        </Modal>
-    </div>
+    <Modal show={isVisible} onHide={onCancel} backdrop={isInProgress ? 'static' : false}>
+        <ModalHeader closeButton={!isInProgress}>
+            <ModalTitle>{title}</ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+            { children || <p>{ text }</p> }
+        </ModalBody>
+        <ModalFooter>
+            { isInProgress ? <Spinner /> : null }
+            &nbsp;
+            <Button onClick={onOk} disabled={isInProgress}>{okButtonText}</Button>
+            {
+                onCancel &&
+                <Button onClick={onCancel} disabled={isInProgress}>
+                    {cancelButtonText}
+                </Button>
+            }
+        </ModalFooter>
+    </Modal>
 );
 
 ConfirmationDialog.propTypes = {

--- a/lib/components/ConfirmationDialog.jsx
+++ b/lib/components/ConfirmationDialog.jsx
@@ -40,52 +40,64 @@ import PropTypes from 'prop-types';
 import { Modal, Button, ModalHeader, ModalFooter, ModalBody, ModalTitle } from 'react-bootstrap';
 import Spinner from './Spinner';
 
+/**
+ * Generic dialog that asks the user to confirm something. The dialog content
+ * and button actions can be customized.
+ *
+ * @param {boolean} isVisible Show the dialog or not.
+ * @param {boolean} [isInProgress] Shows a spinner if true.
+ * @param {string} [title] The dialog title.
+ * @param {Array|*} [children] Array or React element to render in the dialog.
+ * @param {string} [text] Text to render in the dialog. Alternative to `children`.
+ * @param {function} onOk Invoked when the user clicks OK.
+ * @param {function} [onCancel] Invoked when the user cancels. Not showing cancel button if
+ *                              this is not provided.
+ * @param {string} [okButtonText] Label text for the OK button. Default: "OK".
+ * @param {string} [cancelButtonText] Label text for the cancel button. Default: "Cancel".
+ * @returns {*} React element to be rendered.
+ */
 const ConfirmationDialog = ({
-        isVisible,
-        isInProgress,
-        title,
-        text,
-        onOk,
-        onCancel,
-        okButtonText,
-        cancelButtonText,
-        linkText,
-        linkAddress,
-        }) => (
-            <div>
-                <Modal show={isVisible} onHide={onCancel} backdrop={isInProgress ? 'static' : false}>
-                    <ModalHeader closeButton={!isInProgress}>
-                        <ModalTitle>{title}</ModalTitle>
-                    </ModalHeader>
-                    <ModalBody>
-                        <p>{text}</p>
-                        {
-                            linkAddress &&
-                            <a href={linkAddress} target="_blank" rel="noopener noreferrer">
-                                {linkText || linkAddress} </a>
-                        }
-                    </ModalBody>
-                    <ModalFooter>
-                        { isInProgress ? <Spinner /> : null }
-                        &nbsp;
-                        <Button onClick={onOk} disabled={isInProgress}>{okButtonText}</Button>
-                        {
-                            onCancel &&
-                                <Button onClick={onCancel} disabled={isInProgress}>
-                                    {cancelButtonText}
-                                </Button>
-                        }
-                    </ModalFooter>
-                </Modal>
-            </div>
+    isVisible,
+    isInProgress,
+    title,
+    children,
+    text,
+    onOk,
+    onCancel,
+    okButtonText,
+    cancelButtonText,
+}) => (
+    <div>
+        <Modal show={isVisible} onHide={onCancel} backdrop={isInProgress ? 'static' : false}>
+            <ModalHeader closeButton={!isInProgress}>
+                <ModalTitle>{title}</ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+                { children || <p>{ text }</p> }
+            </ModalBody>
+            <ModalFooter>
+                { isInProgress ? <Spinner /> : null }
+                &nbsp;
+                <Button onClick={onOk} disabled={isInProgress}>{okButtonText}</Button>
+                {
+                    onCancel &&
+                    <Button onClick={onCancel} disabled={isInProgress}>
+                        {cancelButtonText}
+                    </Button>
+                }
+            </ModalFooter>
+        </Modal>
+    </div>
 );
 
 ConfirmationDialog.propTypes = {
     isVisible: PropTypes.bool.isRequired,
     title: PropTypes.string,
-    text: PropTypes.string.isRequired,
-    linkText: PropTypes.string,
-    linkAddress: PropTypes.string,
+    text: PropTypes.string,
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]),
     onOk: PropTypes.func.isRequired,
     onCancel: PropTypes.func,
     okButtonText: PropTypes.string,
@@ -95,8 +107,8 @@ ConfirmationDialog.propTypes = {
 
 ConfirmationDialog.defaultProps = {
     title: 'Confirm',
-    linkText: null,
-    linkAddress: null,
+    text: null,
+    children: null,
     isInProgress: false,
     onCancel: null,
     okButtonText: 'OK',

--- a/lib/components/__tests__/__snapshots__/ConfirmationDialog-test.jsx.snap
+++ b/lib/components/__tests__/__snapshots__/ConfirmationDialog-test.jsx.snap
@@ -1,154 +1,146 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfirmationDialog should not render cancel button if onCancel function is not provided 1`] = `
-<div>
-  <Modal
-    backdrop={false}
-    onHide={null}
-    show={true}
+<Modal
+  backdrop={false}
+  onHide={null}
+  show={true}
+>
+  <ModalHeader
+    closeButton={true}
   >
-    <ModalHeader
-      closeButton={true}
+    <ModalTitle>
+      Confirm
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Something happened.
+    </p>
+  </ModalBody>
+  <ModalFooter>
+     
+    <Button
+      disabled={false}
+      onClick={[Function]}
     >
-      <ModalTitle>
-        Confirm
-      </ModalTitle>
-    </ModalHeader>
-    <ModalBody>
-      <p>
-        Something happened.
-      </p>
-    </ModalBody>
-    <ModalFooter>
-       
-      <Button
-        disabled={false}
-        onClick={[Function]}
-      >
-        OK
-      </Button>
-    </ModalFooter>
-  </Modal>
-</div>
+      OK
+    </Button>
+  </ModalFooter>
+</Modal>
 `;
 
 exports[`ConfirmationDialog should render invisible dialog 1`] = `
-<div>
-  <Modal
-    backdrop={false}
-    onHide={[Function]}
-    show={false}
+<Modal
+  backdrop={false}
+  onHide={[Function]}
+  show={false}
+>
+  <ModalHeader
+    closeButton={true}
   >
-    <ModalHeader
-      closeButton={true}
+    <ModalTitle>
+      Confirm
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Do you confirm?
+    </p>
+  </ModalBody>
+  <ModalFooter>
+     
+    <Button
+      disabled={false}
+      onClick={[Function]}
     >
-      <ModalTitle>
-        Confirm
-      </ModalTitle>
-    </ModalHeader>
-    <ModalBody>
-      <p>
-        Do you confirm?
-      </p>
-    </ModalBody>
-    <ModalFooter>
-       
-      <Button
-        disabled={false}
-        onClick={[Function]}
-      >
-        OK
-      </Button>
-      <Button
-        disabled={false}
-        onClick={[Function]}
-      >
-        Cancel
-      </Button>
-    </ModalFooter>
-  </Modal>
-</div>
+      OK
+    </Button>
+    <Button
+      disabled={false}
+      onClick={[Function]}
+    >
+      Cancel
+    </Button>
+  </ModalFooter>
+</Modal>
 `;
 
 exports[`ConfirmationDialog should render visible dialog with text 1`] = `
-<div>
-  <Modal
-    backdrop={false}
-    onHide={[Function]}
-    show={true}
+<Modal
+  backdrop={false}
+  onHide={[Function]}
+  show={true}
+>
+  <ModalHeader
+    closeButton={true}
   >
-    <ModalHeader
-      closeButton={true}
+    <ModalTitle>
+      Confirm
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Do you confirm?
+    </p>
+  </ModalBody>
+  <ModalFooter>
+     
+    <Button
+      disabled={false}
+      onClick={[Function]}
     >
-      <ModalTitle>
-        Confirm
-      </ModalTitle>
-    </ModalHeader>
-    <ModalBody>
-      <p>
-        Do you confirm?
-      </p>
-    </ModalBody>
-    <ModalFooter>
-       
-      <Button
-        disabled={false}
-        onClick={[Function]}
-      >
-        OK
-      </Button>
-      <Button
-        disabled={false}
-        onClick={[Function]}
-      >
-        Cancel
-      </Button>
-    </ModalFooter>
-  </Modal>
-</div>
+      OK
+    </Button>
+    <Button
+      disabled={false}
+      onClick={[Function]}
+    >
+      Cancel
+    </Button>
+  </ModalFooter>
+</Modal>
 `;
 
 exports[`ConfirmationDialog should render visible dialog with text and operation in progress 1`] = `
-<div>
-  <Modal
-    backdrop="static"
-    onHide={[Function]}
-    show={true}
+<Modal
+  backdrop="static"
+  onHide={[Function]}
+  show={true}
+>
+  <ModalHeader
+    closeButton={false}
   >
-    <ModalHeader
-      closeButton={false}
+    <ModalTitle>
+      Confirm
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Do you confirm?
+    </p>
+  </ModalBody>
+  <ModalFooter>
+    <img
+      alt="Loading..."
+      className="core-spinner"
+      height={16}
+      src="test-file-stub"
+      width={16}
+    />
+     
+    <Button
+      disabled={true}
+      onClick={[Function]}
     >
-      <ModalTitle>
-        Confirm
-      </ModalTitle>
-    </ModalHeader>
-    <ModalBody>
-      <p>
-        Do you confirm?
-      </p>
-    </ModalBody>
-    <ModalFooter>
-      <img
-        alt="Loading..."
-        className="core-spinner"
-        height={16}
-        src="test-file-stub"
-        width={16}
-      />
-       
-      <Button
-        disabled={true}
-        onClick={[Function]}
-      >
-        OK
-      </Button>
-      <Button
-        disabled={true}
-        onClick={[Function]}
-      >
-        Cancel
-      </Button>
-    </ModalFooter>
-  </Modal>
-</div>
+      OK
+    </Button>
+    <Button
+      disabled={true}
+      onClick={[Function]}
+    >
+      Cancel
+    </Button>
+  </ModalFooter>
+</Modal>
 `;

--- a/lib/windows/launcher/components/UpdateAvailableDialog.jsx
+++ b/lib/windows/launcher/components/UpdateAvailableDialog.jsx
@@ -45,6 +45,7 @@ import ConfirmationDialog from '../../../components/ConfirmationDialog';
  *
  * @param {boolean} isVisible Show the dialog or not.
  * @param {string} version The new version number that is available.
+ * @param {function} onClickReleaseNotes Invoked when the user clicks to see release notes.
  * @param {function} onConfirm Invoked when the user confirms the upgrade.
  * @param {function} onCancel Invoked when the user cancels the upgrade.
  * @returns {*} React element to be rendered.
@@ -52,6 +53,7 @@ import ConfirmationDialog from '../../../components/ConfirmationDialog';
 const UpdateAvailableDialog = ({
     isVisible,
     version,
+    onClickReleaseNotes,
     onConfirm,
     onCancel,
 }) => (
@@ -62,16 +64,23 @@ const UpdateAvailableDialog = ({
             'Would you like to upgrade now?'}
         okButtonText="Yes"
         cancelButtonText="No"
-        linkText="Click to see release notes"
-        linkAddress="https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases"
         onOk={onConfirm}
         onCancel={onCancel}
-    />
+    >
+        <p>
+            A new version ({version}) of nRF Connect is available. Would you
+            like to upgrade now?
+        </p>
+        <button className="btn btn-link core-btn-link" onClick={onClickReleaseNotes}>
+            Click to see release notes
+        </button>
+    </ConfirmationDialog>
 );
 
 UpdateAvailableDialog.propTypes = {
     isVisible: PropTypes.bool.isRequired,
     version: PropTypes.string.isRequired,
+    onClickReleaseNotes: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
 };

--- a/lib/windows/launcher/components/UpdateAvailableDialog.jsx
+++ b/lib/windows/launcher/components/UpdateAvailableDialog.jsx
@@ -39,6 +39,16 @@ import PropTypes from 'prop-types';
 
 import ConfirmationDialog from '../../../components/ConfirmationDialog';
 
+/**
+ * Dialog that is shown if an nRF Connect core update is available. The user
+ * can either upgrade or cancel.
+ *
+ * @param {boolean} isVisible Show the dialog or not.
+ * @param {string} version The new version number that is available.
+ * @param {function} onConfirm Invoked when the user confirms the upgrade.
+ * @param {function} onCancel Invoked when the user cancels the upgrade.
+ * @returns {*} React element to be rendered.
+ */
 const UpdateAvailableDialog = ({
     isVisible,
     version,
@@ -52,8 +62,10 @@ const UpdateAvailableDialog = ({
             'Would you like to upgrade now?'}
         okButtonText="Yes"
         cancelButtonText="No"
-        onOk={() => onConfirm()}
-        onCancel={() => onCancel()}
+        linkText="Click to see release notes"
+        linkAddress="https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases"
+        onOk={onConfirm}
+        onCancel={onCancel}
     />
 );
 

--- a/lib/windows/launcher/components/UpdateCheckCompleteDialog.jsx
+++ b/lib/windows/launcher/components/UpdateCheckCompleteDialog.jsx
@@ -39,6 +39,16 @@ import PropTypes from 'prop-types';
 
 import ConfirmationDialog from '../../../components/ConfirmationDialog';
 
+/**
+ * Dialog that shows the result after checking for updates. This is
+ * shown after the user has clicked "Check for updates", and lets the user
+ * know if one or more *apps* have updates.
+ *
+ * @param {boolean} isVisible Show the dialog or not.
+ * @param {boolean} isAppUpdateAvailable True if one or more apps have updates.
+ * @param {function} onOk Invoked when user clicks OK.
+ * @returns {*} React element to be rendered.
+ */
 const UpdateCheckSuccessDialog = ({
     isVisible,
     isAppUpdateAvailable,
@@ -51,14 +61,6 @@ const UpdateCheckSuccessDialog = ({
             isAppUpdateAvailable ?
                 'One or more updates are available. Go to the Add/remove apps screen to upgrade.' :
                 'All apps are up to date.'
-        }
-        linkText={
-            isAppUpdateAvailable ? 'Release notes' : ''
-        }
-        linkAddress={
-            isAppUpdateAvailable ?
-                'https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases' :
-                ''
         }
         onOk={onOk}
     />

--- a/lib/windows/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
@@ -38,35 +38,33 @@ exports[`SettingsView should render check for updates completed, with everything
       </button>
     </div>
   </div>
-  <div>
-    <Modal
-      backdrop={false}
-      onHide={null}
-      show={true}
+  <Modal
+    backdrop={false}
+    onHide={null}
+    show={true}
+  >
+    <ModalHeader
+      closeButton={true}
     >
-      <ModalHeader
-        closeButton={true}
+      <ModalTitle>
+        Update check completed
+      </ModalTitle>
+    </ModalHeader>
+    <ModalBody>
+      <p>
+        All apps are up to date.
+      </p>
+    </ModalBody>
+    <ModalFooter>
+       
+      <Button
+        disabled={false}
+        onClick={[Function]}
       >
-        <ModalTitle>
-          Update check completed
-        </ModalTitle>
-      </ModalHeader>
-      <ModalBody>
-        <p>
-          All apps are up to date.
-        </p>
-      </ModalBody>
-      <ModalFooter>
-         
-        <Button
-          disabled={false}
-          onClick={[Function]}
-        >
-          OK
-        </Button>
-      </ModalFooter>
-    </Modal>
-  </div>
+        OK
+      </Button>
+    </ModalFooter>
+  </Modal>
 </div>
 `;
 
@@ -108,35 +106,33 @@ exports[`SettingsView should render check for updates completed, with updates av
       </button>
     </div>
   </div>
-  <div>
-    <Modal
-      backdrop={false}
-      onHide={null}
-      show={true}
+  <Modal
+    backdrop={false}
+    onHide={null}
+    show={true}
+  >
+    <ModalHeader
+      closeButton={true}
     >
-      <ModalHeader
-        closeButton={true}
+      <ModalTitle>
+        Update check completed
+      </ModalTitle>
+    </ModalHeader>
+    <ModalBody>
+      <p>
+        One or more updates are available. Go to the Add/remove apps screen to upgrade.
+      </p>
+    </ModalBody>
+    <ModalFooter>
+       
+      <Button
+        disabled={false}
+        onClick={[Function]}
       >
-        <ModalTitle>
-          Update check completed
-        </ModalTitle>
-      </ModalHeader>
-      <ModalBody>
-        <p>
-          One or more updates are available. Go to the Add/remove apps screen to upgrade.
-        </p>
-      </ModalBody>
-      <ModalFooter>
-         
-        <Button
-          disabled={false}
-          onClick={[Function]}
-        >
-          OK
-        </Button>
-      </ModalFooter>
-    </Modal>
-  </div>
+        OK
+      </Button>
+    </ModalFooter>
+  </Modal>
 </div>
 `;
 

--- a/lib/windows/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
@@ -55,7 +55,6 @@ exports[`SettingsView should render check for updates completed, with everything
         <p>
           All apps are up to date.
         </p>
-        
       </ModalBody>
       <ModalFooter>
          
@@ -126,14 +125,6 @@ exports[`SettingsView should render check for updates completed, with updates av
         <p>
           One or more updates are available. Go to the Add/remove apps screen to upgrade.
         </p>
-        <a
-          href="https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Release notes
-           
-        </a>
       </ModalBody>
       <ModalFooter>
          

--- a/lib/windows/launcher/containers/UpdateAvailableContainer.js
+++ b/lib/windows/launcher/containers/UpdateAvailableContainer.js
@@ -35,11 +35,12 @@
  */
 
 import { connect } from 'react-redux';
+import { remote } from 'electron';
 import UpdateAvailableDialog from '../components/UpdateAvailableDialog';
 import * as AutoUpdateActions from '../actions/autoUpdateActions';
 import { openUrlInDefaultBrowser } from '../../../util/fileUtil';
 
-const releaseNotesUrl = 'https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases';
+const config = remote.require('./main/config');
 
 function mapStateToProps(state) {
     const { autoUpdate } = state;
@@ -52,7 +53,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        onClickReleaseNotes: () => openUrlInDefaultBrowser(releaseNotesUrl),
+        onClickReleaseNotes: () => openUrlInDefaultBrowser(config.getReleaseNotesUrl()),
         onConfirm: () => dispatch(AutoUpdateActions.startDownload()),
         onCancel: () => dispatch(AutoUpdateActions.postponeUpdate()),
     };

--- a/lib/windows/launcher/containers/UpdateAvailableContainer.js
+++ b/lib/windows/launcher/containers/UpdateAvailableContainer.js
@@ -37,6 +37,9 @@
 import { connect } from 'react-redux';
 import UpdateAvailableDialog from '../components/UpdateAvailableDialog';
 import * as AutoUpdateActions from '../actions/autoUpdateActions';
+import { openUrlInDefaultBrowser } from '../../../util/fileUtil';
+
+const releaseNotesUrl = 'https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases';
 
 function mapStateToProps(state) {
     const { autoUpdate } = state;
@@ -49,6 +52,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
+        onClickReleaseNotes: () => openUrlInDefaultBrowser(releaseNotesUrl),
         onConfirm: () => dispatch(AutoUpdateActions.startDownload()),
         onCancel: () => dispatch(AutoUpdateActions.postponeUpdate()),
     };

--- a/main/config.js
+++ b/main/config.js
@@ -58,6 +58,7 @@ let appsJsonPath;
 let appsJsonUrl;
 let settingsJsonPath;
 let registryUrl;
+let releaseNotesUrl;
 let skipUpdateApps;
 let skipUpdateCore;
 let skipSplashScreen;
@@ -101,6 +102,7 @@ function init(argv) {
     settingsJsonPath = argv['settings-json-path'] || path.join(userDataDir, 'settings.json');
     appsJsonUrl = 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfconnect-core/master/apps.json';
     registryUrl = 'https://registry.yarnpkg.com';
+    releaseNotesUrl = 'https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases';
     skipUpdateApps = argv['skip-update-apps'] || false;
     skipUpdateCore = argv['skip-update-core'] || false;
     skipSplashScreen = argv['skip-splash-screen'] || false;
@@ -128,6 +130,7 @@ module.exports = {
     getSettingsJsonPath: () => settingsJsonPath,
     getAppsJsonUrl: () => appsJsonUrl,
     getRegistryUrl: () => registryUrl,
+    getReleaseNotesUrl: () => releaseNotesUrl,
     isSkipUpdateApps: () => skipUpdateApps,
     isSkipUpdateCore: () => skipUpdateCore,
     isSkipSplashScreen: () => skipSplashScreen,

--- a/resources/css/launcher.less
+++ b/resources/css/launcher.less
@@ -132,6 +132,7 @@ html, body, #webapp {
 }
 
 .core-btn-link {
+    border: none;
     padding: 0;
 }
 


### PR DESCRIPTION
A link to nRF Connect release notes was added in #148, but it was added to the wrong dialog. There is one dialog that informs the user if there are app updates after clicking "Check for updates now", and one that pops up by itself if the auto-update mechanism detects a new core version. The latter is where we want the link to be, so I have moved it there.

The components were poorly documented, and can I understand that this was confusing. Added some documentation for the components to make it more clear. Also changed the link so that it opens the release notes in the user's default browser instead of an Electron browser window.

![image](https://user-images.githubusercontent.com/461755/35378784-4b2b8d52-01b4-11e8-9b4f-17250d98e5cc.png)