### PR TITLE
 Do not show progress during Linux auto updates

### DIFF
--- a/lib/windows/launcher/actions/autoUpdateActions.js
+++ b/lib/windows/launcher/actions/autoUpdateActions.js
@@ -67,6 +67,7 @@ function updateAvailableAction(version) {
 function startDownloadAction() {
     return {
         type: AUTO_UPDATE_START_DOWNLOAD,
+        isProgressSupported: true,
         isCancelSupported: isWindows,
     };
 }

--- a/lib/windows/launcher/actions/autoUpdateActions.js
+++ b/lib/windows/launcher/actions/autoUpdateActions.js
@@ -50,6 +50,7 @@ export const AUTO_UPDATE_ERROR = 'AUTO_UPDATE_ERROR';
 const { autoUpdater, CancellationToken } = remote.require('./main/autoUpdate');
 const cancellationToken = new CancellationToken();
 const isWindows = process.platform === 'win32';
+const isMac = process.platform === 'darwin';
 
 function checkAction() {
     return {
@@ -67,7 +68,7 @@ function updateAvailableAction(version) {
 function startDownloadAction() {
     return {
         type: AUTO_UPDATE_START_DOWNLOAD,
-        isProgressSupported: true,
+        isProgressSupported: isWindows || isMac,
         isCancelSupported: isWindows,
     };
 }

--- a/lib/windows/launcher/components/UpdateProgressDialog.jsx
+++ b/lib/windows/launcher/components/UpdateProgressDialog.jsx
@@ -37,9 +37,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button, ModalHeader, ModalFooter, ModalBody, ModalTitle, ProgressBar } from 'react-bootstrap';
+import Spinner from '../../../components/Spinner';
 
 const UpdateProgressDialog = ({
     isVisible,
+    isProgressSupported,
     isCancelSupported,
     version,
     percentDownloaded,
@@ -52,13 +54,20 @@ const UpdateProgressDialog = ({
         </ModalHeader>
         <ModalBody>
             <p>Downloading nRF Connect {version}...</p>
-            <ProgressBar label={`${percentDownloaded}%`} now={percentDownloaded} />
+            {
+                isProgressSupported &&
+                    <ProgressBar label={`${percentDownloaded}%`} now={percentDownloaded} />
+            }
             <p>
                 This might take a few minutes. The application will restart and update
                 once the download is complete.
             </p>
         </ModalBody>
         <ModalFooter>
+            {
+                !isProgressSupported &&
+                    <Spinner />
+            }
             {
                 isCancelSupported &&
                     <Button onClick={onCancel} disabled={isCancelling}>Cancel</Button>
@@ -69,6 +78,7 @@ const UpdateProgressDialog = ({
 
 UpdateProgressDialog.propTypes = {
     isVisible: PropTypes.bool.isRequired,
+    isProgressSupported: PropTypes.bool.isRequired,
     isCancelSupported: PropTypes.bool.isRequired,
     version: PropTypes.string.isRequired,
     percentDownloaded: PropTypes.number.isRequired,

--- a/lib/windows/launcher/components/__tests__/UpdateProgressDialog-test.jsx
+++ b/lib/windows/launcher/components/__tests__/UpdateProgressDialog-test.jsx
@@ -56,6 +56,7 @@ describe('UpdateProgressDialog', () => {
         expect(renderer.create(
             <UpdateProgressDialog
                 isVisible={false}
+                isProgressSupported={false}
                 isCancelSupported={false}
                 version=""
                 percentDownloaded={0}
@@ -69,6 +70,7 @@ describe('UpdateProgressDialog', () => {
         expect(renderer.create(
             <UpdateProgressDialog
                 isVisible
+                isProgressSupported
                 isCancelSupported
                 version="1.2.3"
                 percentDownloaded={42}
@@ -78,10 +80,11 @@ describe('UpdateProgressDialog', () => {
         )).toMatchSnapshot();
     });
 
-    it('should render with version and not cancellable', () => {
+    it('should render with version, without progress, and not cancellable', () => {
         expect(renderer.create(
             <UpdateProgressDialog
                 isVisible
+                isProgressSupported={false}
                 isCancelSupported={false}
                 version="1.2.3"
                 percentDownloaded={0}
@@ -95,6 +98,7 @@ describe('UpdateProgressDialog', () => {
         expect(renderer.create(
             <UpdateProgressDialog
                 isVisible
+                isProgressSupported
                 isCancelSupported
                 version="1.2.3"
                 percentDownloaded={42}

--- a/lib/windows/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
@@ -55,45 +55,19 @@ exports[`UpdateProgressDialog should render invisible 1`] = `
       
       ...
     </p>
-    <ProgressBar
-      label="0%"
-      now={0}
-    />
     <p>
       This might take a few minutes. The application will restart and update once the download is complete.
     </p>
   </ModalBody>
-  <ModalFooter />
-</Modal>
-`;
-
-exports[`UpdateProgressDialog should render with version and not cancellable 1`] = `
-<Modal
-  backdrop={true}
-  show={true}
->
-  <ModalHeader
-    closeButton={false}
-  >
-    <ModalTitle>
-      Downloading update
-    </ModalTitle>
-  </ModalHeader>
-  <ModalBody>
-    <p>
-      Downloading nRF Connect 
-      1.2.3
-      ...
-    </p>
-    <ProgressBar
-      label="0%"
-      now={0}
+  <ModalFooter>
+    <img
+      alt="Loading..."
+      className="core-spinner"
+      height={16}
+      src="test-file-stub"
+      width={16}
     />
-    <p>
-      This might take a few minutes. The application will restart and update once the download is complete.
-    </p>
-  </ModalBody>
-  <ModalFooter />
+  </ModalFooter>
 </Modal>
 `;
 
@@ -130,6 +104,40 @@ exports[`UpdateProgressDialog should render with version, percent downloaded, an
     >
       Cancel
     </Button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`UpdateProgressDialog should render with version, without progress, and not cancellable 1`] = `
+<Modal
+  backdrop={true}
+  show={true}
+>
+  <ModalHeader
+    closeButton={false}
+  >
+    <ModalTitle>
+      Downloading update
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Downloading nRF Connect 
+      1.2.3
+      ...
+    </p>
+    <p>
+      This might take a few minutes. The application will restart and update once the download is complete.
+    </p>
+  </ModalBody>
+  <ModalFooter>
+    <img
+      alt="Loading..."
+      className="core-spinner"
+      height={16}
+      src="test-file-stub"
+      width={16}
+    />
   </ModalFooter>
 </Modal>
 `;

--- a/lib/windows/launcher/containers/UpdateProgressContainer.js
+++ b/lib/windows/launcher/containers/UpdateProgressContainer.js
@@ -43,6 +43,7 @@ function mapStateToProps(state) {
 
     return {
         isVisible: autoUpdate.isUpdateProgressDialogVisible,
+        isProgressSupported: autoUpdate.isProgressSupported,
         isCancelSupported: autoUpdate.isCancelSupported,
         version: autoUpdate.latestVersion,
         percentDownloaded: autoUpdate.percentDownloaded,

--- a/lib/windows/launcher/reducers/__tests__/autoUpdateReducer-test.js
+++ b/lib/windows/launcher/reducers/__tests__/autoUpdateReducer-test.js
@@ -102,11 +102,20 @@ describe('autoUpdateReducer', () => {
         expect(state.isUpdateProgressDialogVisible).toEqual(true);
     });
 
-    it('should not have cancel support when AUTO_UPDATE_START_DOWNLOAD has been dispatched without it', () => {
+    it('should not have progress/cancel support when AUTO_UPDATE_START_DOWNLOAD has been dispatched without it', () => {
         const state = reducer(initialState, {
             type: AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD,
         });
+        expect(state.isProgressSupported).toEqual(false);
         expect(state.isCancelSupported).toEqual(false);
+    });
+
+    it('should set progress support when AUTO_UPDATE_START_DOWNLOAD has been dispatched with progress support', () => {
+        const state = reducer(initialState, {
+            type: AutoUpdateActions.AUTO_UPDATE_START_DOWNLOAD,
+            isProgressSupported: true,
+        });
+        expect(state.isProgressSupported).toEqual(true);
     });
 
     it('should set cancel support when AUTO_UPDATE_START_DOWNLOAD has been dispatched with cancel support', () => {

--- a/lib/windows/launcher/reducers/autoUpdateReducer.js
+++ b/lib/windows/launcher/reducers/autoUpdateReducer.js
@@ -40,6 +40,7 @@ import * as AutoUpdateActions from '../actions/autoUpdateActions';
 const InitialState = Record({
     isUpdateAvailableDialogVisible: false,
     isUpdateProgressDialogVisible: false,
+    isProgressSupported: false,
     isCancelSupported: false,
     latestVersion: '',
     percentDownloaded: 0,
@@ -57,6 +58,7 @@ function setDownloading(state, action) {
     return state
         .set('isUpdateAvailableDialogVisible', false)
         .set('isUpdateProgressDialogVisible', true)
+        .set('isProgressSupported', !!action.isProgressSupported)
         .set('isCancelSupported', !!action.isCancelSupported);
 }
 


### PR DESCRIPTION
The electron-updater does not emit progress updates when downloading on Linux. Showing a spinner instead of the progress bar.