### PR TITLE
Fixed app icon generation issues

### DIFF
--- a/lib/windows/launcher/actions/desktopShortcutActions.js
+++ b/lib/windows/launcher/actions/desktopShortcutActions.js
@@ -92,15 +92,14 @@ function createShortcutForWindows(app) {
         const filePath = path.join(config.getDesktopDir(), `${fileName}.lnk`);
         if (app.shortcutIconPath) {
             // TODO: This implementation is duplicated due to compatitbility, remove it later.
-            const suffix = app.shortcutIconPath.substring(3);
             let icoPath;
-            if (suffix === 'ico') {
+            if (app.shortcutIconPath.endsWith('.ico')) {
                 icoPath = app.shortcutIconPath;
             } else {
                 // Convert ico file for the app
                 icoPath = path.join(app.path, 'icon.ico');
                 const input = fs.readFileSync(app.iconPath);
-                const output = png2icons.PNG2ICO_PNG(input, png2icons.BILINEAR, false, 0);
+                const output = png2icons.PNG2ICO_BMP(input, png2icons.HERMITE, false);
                 if (output) {
                     fs.writeFileSync(icoPath, output);
                 }
@@ -231,11 +230,8 @@ function createShortcutForMacOS(app) {
         .then(() => fileUtil.chmodDir(tmpAppTemplatePath, mode))
         .then(() => {
             // TODO: This implementation is duplicated due to compatitbility, remove it later.
-            if (app.shortcutIconPath) {
-                const suffix = app.shortcutIconPath.substring(4);
-                if (suffix === 'icns') {
-                    return fileUtil.copy(app.shortcutIconPath, icnsPath);
-                }
+            if (app.shortcutIconPath && app.shortcutIconPath.endsWith('.icns')) {
+                return fileUtil.copy(app.shortcutIconPath, icnsPath);
             }
             // Convert icns file for the app
             const input = fs.readFileSync(app.iconPath);


### PR DESCRIPTION
- Windows is not capable of correctly displaying PNG based .ico files, generating BMP based ones instead
- Condition to check for pregenerated icons fixed