### PR TITLE
Fix long delay during update on Windows 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "chmodr": "1.0.2",
         "electron-builder-http": "18.5.1",
         "electron-log": "2.2.6",
-        "electron-updater": "2.18.2",
+        "electron-updater": "2.20.2",
         "fs-extra": "4.0.1",
         "mustache": "2.3.0",
         "pc-ble-driver-js": "2.2.2",


### PR DESCRIPTION
When updating the application on Windows 7 the progress bar showed 100% for 30 seconds before restarting and installing the update. This was due to a bug in electron-updater, which has been fixed in v2.20.2.