### PR TITLE
Update devdep version to fix jsx linting issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "electron-is-dev": "0.1.2",
         "moment": "2.18.1",
         "mousetrap": "1.6.1",
-        "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#v1.2.1",
+        "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^1.2.2",
         "react-infinite": "github:NordicSemiconductor/react-infinite#react-15.5",
         "redux-logger": "3.0.1",
         "redux-thunk": "2.2.0",


### PR DESCRIPTION
Also now using semver caret in dependency, so that we get new patch or minor versions automatically.