### PR TITLE
Implement HotkeyedDropdown for the device selector

### DIFF
--- a/lib/components/HotkeyedDropdown.jsx
+++ b/lib/components/HotkeyedDropdown.jsx
@@ -1,0 +1,38 @@
+
+import { Dropdown } from 'react-bootstrap';
+import Mousetrap from 'mousetrap';
+import React from 'react';
+
+// Like react-bootstrap's `Dropdown`, but can receive an extra `hotkey` prop:
+// a key combination handled by `mousetrap` that will toggle the open state
+// of the dropdown.
+
+export default class HotkeyedDropdown extends Dropdown {
+    constructor(props) {
+        super(props);
+        this.state = { open: false };
+    }
+
+    componentDidMount() {
+        Mousetrap.bind(this.props.hotkey, () => { this.toggle(); });
+    }
+
+    componentWillUnmount() {
+        Mousetrap.unbind(this.props.hotkey);
+    }
+
+    toggle() {
+        this.setState({ open: !this.state.open });
+    }
+
+    render() {
+        const childProps = Object.assign({}, this.props);
+        delete childProps.hotkey;
+        return (<Dropdown
+            {...childProps}
+            open={this.state.open && !this.props.disabled}
+            onToggle={() => { this.toggle(); }}
+        />);
+    }
+}
+

--- a/lib/windows/app/components/DeviceSelector.jsx
+++ b/lib/windows/app/components/DeviceSelector.jsx
@@ -36,10 +36,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown, MenuItem } from 'react-bootstrap';
+import { MenuItem } from 'react-bootstrap';
 import DropdownToggle from 'react-bootstrap/lib/DropdownToggle';
 import DropdownMenu from 'react-bootstrap/lib/DropdownMenu';
 
+import Dropdown from '../../../components/HotkeyedDropdown';
 
 // Stateless, templating-only component. Used only from ../containers/DeviceSelectorContainer
 export default class DeviceSelector extends React.Component {
@@ -118,11 +119,16 @@ export default class DeviceSelector extends React.Component {
         const closeItem = displayCloseItem ? this.getCloseItem() : undefined;
 
         return (
-            <Dropdown id="device-selector" className={cssClass} disabled={devices.length === 0}>
+            <Dropdown
+                id="device-selector"
+                className={cssClass}
+                disabled={devices.length === 0}
+                hotkey="alt+p"
+            >
                 <DropdownToggle
                     className={dropdownCssClass}
-                    title={togglerText}
-                />
+                    title={`${togglerText} (Alt+P)`}
+                >{togglerText} </DropdownToggle>
                 <DropdownMenu
                     id="device-selector-list"
                     className={dropdownMenuCssClass}


### PR DESCRIPTION
Bring back the hotkey for the dropdown as per https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/174#discussion_r172514380 . This is not using `withHotkey` because I think that abstraction doesn't really fit well here (it fits well when the state is hoisted up to the global state and actions are dispatched away, though).

Note this PR targets the `device-selector` branch, not `master`.