### PR TITLE
Use withHotkey for the device selector

### DIFF
--- a/lib/windows/app/components/DeviceSelector.jsx
+++ b/lib/windows/app/components/DeviceSelector.jsx
@@ -35,6 +35,7 @@
  */
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import DropdownToggle from 'react-bootstrap/lib/DropdownToggle';
@@ -43,6 +44,20 @@ import DropdownMenu from 'react-bootstrap/lib/DropdownMenu';
 
 // Stateless, templating-only component. Used only from ../containers/DeviceSelectorContainer
 export default class DeviceSelector extends React.Component {
+    /**
+     * React lifecycle method that is invoked before the component
+     * renders.
+     *
+     * @param {object} nextProps Props that will be used for the next render.
+     * @returns {void}
+     */
+    componentWillReceiveProps(nextProps) {
+        const isExpanding = !this.props.isExpanded && nextProps.isExpanded;
+        if (isExpanding) {
+            this.focusDropdownButton();
+        }
+    }
+
     /**
      * Returns the JSX that corresponds to a "Close device" menu item.
      * If no device is selected, then no close item is rendered.
@@ -100,6 +115,23 @@ export default class DeviceSelector extends React.Component {
                 </ul>
             </MenuItem>
         );
+    }
+
+    /**
+     * Focuses the selector dropdown button. This is needed to make the
+     * up/down arrow keys work when the selector is expanded.
+     *
+     * @returns {void}
+     */
+    focusDropdownButton() {
+        // eslint-disable-next-line react/no-find-dom-node
+        const node = ReactDOM.findDOMNode(this);
+        if (node) {
+            const button = node.querySelector('button');
+            if (button) {
+                button.focus();
+            }
+        }
     }
 
     /*

--- a/lib/windows/app/components/DeviceSelector.jsx
+++ b/lib/windows/app/components/DeviceSelector.jsx
@@ -154,6 +154,8 @@ DeviceSelector.propTypes = {
     togglerText: PropTypes.string.isRequired,
     displayCloseItem: PropTypes.bool.isRequired,
     devices: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    isExpanded: PropTypes.bool.isRequired,
+    onToggle: PropTypes.func.isRequired,
 };
 
 DeviceSelector.defaultProps = {

--- a/lib/windows/app/components/DeviceSelector.jsx
+++ b/lib/windows/app/components/DeviceSelector.jsx
@@ -113,12 +113,20 @@ export default class DeviceSelector extends React.Component {
             togglerText,
             displayCloseItem,   // bool
             devices, // plain array, not map
+            isExpanded,
+            onToggle,
         } = this.props;
 
         const closeItem = displayCloseItem ? this.getCloseItem() : undefined;
 
         return (
-            <Dropdown id="device-selector" className={cssClass} disabled={devices.length === 0}>
+            <Dropdown
+                id="device-selector"
+                className={cssClass}
+                disabled={devices.length === 0}
+                open={isExpanded}
+                onToggle={onToggle}
+            >
                 <DropdownToggle
                     className={dropdownCssClass}
                     title={togglerText}

--- a/lib/windows/app/containers/DeviceSelectorContainer.jsx
+++ b/lib/windows/app/containers/DeviceSelectorContainer.jsx
@@ -69,7 +69,7 @@ import withHotkey from '../../../util/withHotkey';
  * stays in ../components/DeviceSelector
  */
 
-class DeviceSelectorContainer extends React.Component {
+class DeviceSelectorContainer extends withHotkey(React.Component) {
     constructor(props) {
         super(props);
 
@@ -112,7 +112,7 @@ class DeviceSelectorContainer extends React.Component {
     }
 
     componentDidMount() {
-        this.props.bindHotkey('alt+p', () => {
+        this.bindHotkey('alt+p', () => {
             this.onToggle();
         });
     }
@@ -209,4 +209,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
     args => args,
     mapDispatchToProps,
-)(withHotkey(DeviceSelectorContainer), 'DeviceSelector');
+)(DeviceSelectorContainer, 'DeviceSelector');

--- a/lib/windows/app/containers/DeviceSelectorContainer.jsx
+++ b/lib/windows/app/containers/DeviceSelectorContainer.jsx
@@ -69,7 +69,7 @@ import withHotkey from '../../../util/withHotkey';
  * stays in ../components/DeviceSelector
  */
 
-class DeviceSelectorContainer extends withHotkey(React.Component) {
+class DeviceSelectorContainer extends React.Component {
     constructor(props) {
         super(props);
 
@@ -112,7 +112,7 @@ class DeviceSelectorContainer extends withHotkey(React.Component) {
     }
 
     componentDidMount() {
-        this.bindHotkey('alt+p', () => {
+        this.props.bindHotkey('alt+p', () => {
             this.onToggle();
         });
     }
@@ -185,6 +185,7 @@ class DeviceSelectorContainer extends withHotkey(React.Component) {
 DeviceSelectorContainer.propTypes = {
     onSelect: PropTypes.func.isRequired,
     onDeselect: PropTypes.func.isRequired,
+    bindHotkey: PropTypes.func.isRequired,
     traits: PropTypes.shape({}),
 };
 
@@ -209,4 +210,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
     args => args,
     mapDispatchToProps,
-)(DeviceSelectorContainer, 'DeviceSelector');
+)(withHotkey(DeviceSelectorContainer), 'DeviceSelector');

--- a/lib/windows/app/containers/DeviceSelectorContainer.jsx
+++ b/lib/windows/app/containers/DeviceSelectorContainer.jsx
@@ -78,6 +78,7 @@ class DeviceSelectorContainer extends React.Component {
         this.state = {
             devices: [],
             selectedSerialNumber: undefined,
+            isExpanded: false,
         };
 
         this.deviceLister.on('conflated', devices => {

--- a/lib/windows/app/containers/DeviceSelectorContainer.jsx
+++ b/lib/windows/app/containers/DeviceSelectorContainer.jsx
@@ -42,6 +42,7 @@ import PropTypes from 'prop-types';
 import DeviceSelector from '../components/DeviceSelector';
 import { connect } from '../../../util/apps';
 import { logger } from '../../../api/logging';
+import withHotkey from '../../../util/withHotkey';
 
 /*
  * Stateful device selector.
@@ -110,6 +111,13 @@ class DeviceSelectorContainer extends React.Component {
         this.deviceLister.start();
     }
 
+    componentDidMount() {
+        this.props.bindHotkey('alt+p', () => {
+            this.onToggle();
+        });
+    }
+
+
     /*
      * Called from the templated selector.
      * Shall receive a device definition.
@@ -136,6 +144,10 @@ class DeviceSelectorContainer extends React.Component {
         this.props.onDeselect();
     }
 
+    onToggle() {
+        this.setState(prev => ({ ...prev, isExpanded: !prev.isExpanded }));
+    }
+
     /*
      * Returns the JSX corresponding to a drop-down menu.
      * Prepares some properties for the template, uses it.
@@ -160,6 +172,8 @@ class DeviceSelectorContainer extends React.Component {
             devices,
             onSelect: device => { this.onSelect(device); },
             onDeselect: () => { this.onDeselect(); },
+            onToggle: () => { this.onToggle(); },
+            isExpanded: this.state.isExpanded,
         };
 
         return (
@@ -195,4 +209,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
     args => args,
     mapDispatchToProps,
-)(DeviceSelectorContainer, 'DeviceSelector');
+)(withHotkey(DeviceSelectorContainer), 'DeviceSelector');


### PR DESCRIPTION
Alternative to #180, as suggested by https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/180#issuecomment-371140677

I'm not a fan of this approach, because I think it increases coupling and the current way of applying class mixins is truly confusing (see https://github.com/NordicSemiconductor/pc-nrfconnect-core/commit/96b8f806381791ed2c2a525b9d8c52cc22a9f568 - both before and after works, which is very weird IMO)