### PR TITLE
Add jsdoc for all core actions

### DIFF
--- a/lib/windows/app/actions/firmwareDialogActions.js
+++ b/lib/windows/app/actions/firmwareDialogActions.js
@@ -34,9 +34,33 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * Indicates that the FirmwareDialog should be shown, which asks the user if
+ * the firmware for the given port should be updated. Apps will typically
+ * dispatch this action to show the FirmwareDialog to the user.
+ *
+ * @param {Object} port Serial port object, ref. the serialport library.
+ */
 export const FIRMWARE_DIALOG_SHOW = 'FIRMWARE_DIALOG_SHOW';
+
+/**
+ * Indicates that the FirmwareDialog should be hidden. Apps will typically
+ * dispatch this action to hide the FirmwareDialog after a firmware update
+ * has completed or failed.
+ */
 export const FIRMWARE_DIALOG_HIDE = 'FIRMWARE_DIALOG_HIDE';
+
+/**
+ * Indicates that updating the firmware for the given port has been requested.
+ *
+ * Apps can listen to this action in middleware, and implement their own
+ * firmware update routine. This will typically involve calling pc-nrfjprog-js
+ * with the firmware that the app requires.
+ *
+ * @param {Object} port Serial port object, ref. the serialport library.
+ */
 export const FIRMWARE_DIALOG_UPDATE_REQUESTED = 'FIRMWARE_DIALOG_UPDATE_REQUESTED';
+
 
 export function showDialog(port) {
     return {

--- a/lib/windows/app/actions/logActions.js
+++ b/lib/windows/app/actions/logActions.js
@@ -39,12 +39,48 @@ import { logger, logBuffer, getLogFilePath } from '../../../api/logging';
 import { getAppDataDir } from '../../../api/core';
 import { openFileInDefaultApplication } from '../../../util/fileUtil';
 
+/**
+ * Indicates that adding of log entries have been requested. This is dispatched
+ * at regular intervals when some part of the application (core framework or app)
+ * has used the winston logger instance to log something.
+ *
+ * @param {Array} entries Array of objects with id (number), time (Date), level
+ * (number), message (string), and meta (object) properties.
+ */
 export const ADD_ENTRIES = 'LOG_ADD_ENTRIES';
+
+/**
+ * Indicates that opening the application's log file has been requested.
+ *
+ * @deprecated
+ */
 export const OPEN_FILE = 'LOG_OPEN_FILE';
+
+/**
+ * Indicates that opening the application's log file succeeded.
+ *
+ * @deprecated
+ */
 export const OPEN_FILE_SUCCESS = 'LOG_OPEN_FILE_SUCCESS';
+
+/**
+ * Indicates that opening the application's log file failed.
+ *
+ * @deprecated
+ * @param {string} message An error message describing why opening failed.
+ */
 export const OPEN_FILE_ERROR = 'LOG_OPEN_FILE_ERROR';
+
+/**
+ * Indicates that clearing of all log entries in state has been requested.
+ */
 export const CLEAR_ENTRIES = 'LOG_CLEAR_ENTRIES';
+
+/**
+ * Indicates that toggling of auto scrolling in the LogViewer has been requested.
+ */
 export const TOGGLE_AUTOSCROLL = 'LOG_TOGGLE_AUTOSCROLL';
+
 
 const LOG_UPDATE_INTERVAL = 400;
 let logListenerTimeout;
@@ -87,6 +123,13 @@ function toggleAutoScrollAction() {
     };
 }
 
+/**
+ * Listens to new log entries on every LOG_UPDATE_INTERVAL, and adds any
+ * new entries that may have arrived in this the interval.
+ *
+ * @param {function} dispatch The redux dispatch function.
+ * @returns {void}
+ */
 function listenToLogUpdates(dispatch) {
     if (logBuffer.size() > 0) {
         const entries = logBuffer.clear();
@@ -126,6 +169,13 @@ export function clear() {
     return clearEntriesAction();
 }
 
+/**
+ * Starts listening to new log entries from the application's log buffer.
+ * Incoming entries are added to the state, so that they can be displayed
+ * in the UI.
+ *
+ * @returns {function(*)} Function that can be passed to redux dispatch.
+ */
 export function startReading() {
     return dispatch => {
         logger.info(`Application data folder: ${getAppDataDir()}`);

--- a/lib/windows/app/actions/mainMenuActions.js
+++ b/lib/windows/app/actions/mainMenuActions.js
@@ -36,7 +36,13 @@
 
 import { ipcRenderer } from 'electron';
 
+/**
+ * Indicates that opening the nRF Connect app launcher has been requested.
+ *
+ * @deprecated
+ */
 export const OPEN_APP_LAUNCHER = 'MAIN_MENU_OPEN_APP_LAUNCHER';
+
 
 function openAppLauncherAction() {
     return {

--- a/lib/windows/app/actions/navMenuActions.js
+++ b/lib/windows/app/actions/navMenuActions.js
@@ -34,7 +34,17 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * Indicates that a navigation menu (NavMenu) item has been selected.
+ *
+ * Apps that use the NavMenu can listen to this action in their middleware to add
+ * custom behavior when an item is selected. Apps can also dispatch this action
+ * themselves to select a menu item.
+ *
+ * @param {number} The menu item ID.
+ */
 export const ITEM_SELECTED = 'NAV_MENU_ITEM_SELECTED';
+
 
 export function menuItemSelected(id) {
     return {

--- a/lib/windows/app/actions/serialPortActions.js
+++ b/lib/windows/app/actions/serialPortActions.js
@@ -38,12 +38,53 @@ import SerialPort from 'serialport';
 import { isPortAvailable, decorateWithSerialNumber } from '../../../api/jlink';
 import { logger } from '../../../api/logging';
 
+/**
+ * Indicates that loading all available serial ports has been requested. This action is
+ * normally followed by either SERIAL_PORTS_LOAD_SUCCESS or SERIAL_PORTS_LOAD_ERROR
+ * to indicate success or failure.
+ */
 export const SERIAL_PORTS_LOAD = 'SERIAL_PORTS_LOAD';
+
+/**
+ * Indicates that loading of serial ports was successful.
+ *
+ * @param {Array} ports Array of serial port objects, ref. the serialport library.
+ */
 export const SERIAL_PORTS_LOAD_SUCCESS = 'SERIAL_PORTS_LOAD_SUCCESS';
+
+/**
+ * Indicates that loading of serial ports failed.
+ *
+ * @param {string} message Error message from the subsystem.
+ */
 export const SERIAL_PORTS_LOAD_ERROR = 'SERIAL_PORTS_LOAD_ERROR';
+
+/**
+ * Indicates that the expanded state of the SerialPortSelector was toggled.
+ */
 export const SERIAL_PORT_SELECTOR_TOGGLE_EXPANDED = 'SERIAL_PORT_SELECTOR_TOGGLE_EXPANDED';
+
+/**
+ * Indicates that a serial port was selected.
+ *
+ * Apps can listen to this action in their middleware to add custom behavior when
+ * the port is selected, f.ex. opening the port or checking its firmware. Apps can
+ * also dispatch this action themselves to make the port appear as selected in the
+ * SerialPortSelector.
+ *
+ * @param {Object} port Serial port object, ref. the serialport library.
+ */
 export const SERIAL_PORT_SELECTED = 'SERIAL_PORT_SELECTED';
+
+/**
+ * Indicates that a serial port was deselected.
+ *
+ * Apps can listen to this action in their middleware to add custom behavior when
+ * the port is deselected, f.ex. closing the port. Apps can also dispatch this action
+ * themselves to clear a selection in the SerialPortSelector.
+ */
 export const SERIAL_PORT_DESELECTED = 'SERIAL_PORT_DESELECTED';
+
 
 function loadPortsAction() {
     return {


### PR DESCRIPTION
Could perhaps consider generating HTML documentation of this at some point if we find it useful.