### PR TITLE
Abstract the "focus selector on hotkey" logic, minimal approach

### DIFF
--- a/lib/windows/app/components/AbstractSelector.jsx
+++ b/lib/windows/app/components/AbstractSelector.jsx
@@ -1,0 +1,52 @@
+
+import ReactDOM from 'react-dom';
+import React from 'react';
+
+
+// Base class for the serial port and device selector.
+// Implements the common hotkey logic.
+// Depends on the concrete class having the `isExpanded`, `onToggle` and `bindHotkey`
+// props
+
+export default class AbstractDeviceSelector extends React.Component {
+
+    componentDidMount() {
+        const {
+            bindHotkey,
+            onToggle,
+        } = this.props;
+
+        bindHotkey('alt+p', () => {
+            // Focusing the dropdown button, so that up/down arrow keys
+            // can be used to select serial port.
+            this.focusDropdownButton();
+            onToggle();
+        });
+    }
+
+    /**
+     * React lifecycle method that is invoked before the component
+     * renders.
+     *
+     * @param {object} nextProps Props that will be used for the next render.
+     * @returns {void}
+     */
+    componentWillReceiveProps(nextProps) {
+        const isExpanding = !this.props.isExpanded && nextProps.isExpanded;
+        if (isExpanding) {
+            this.focusDropdownButton();
+        }
+    }
+
+
+    focusDropdownButton() {
+        // eslint-disable-next-line react/no-find-dom-node
+        const node = ReactDOM.findDOMNode(this);
+        if (node) {
+            const button = node.querySelector('button');
+            if (button) {
+                button.focus();
+            }
+        }
+    }
+}

--- a/lib/windows/app/components/DeviceSelector.jsx
+++ b/lib/windows/app/components/DeviceSelector.jsx
@@ -35,29 +35,17 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+// import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import DropdownToggle from 'react-bootstrap/lib/DropdownToggle';
 import DropdownMenu from 'react-bootstrap/lib/DropdownMenu';
 
+import AbstractSelector from './AbstractSelector';
+
 
 // Stateless, templating-only component. Used only from ../containers/DeviceSelectorContainer
-export default class DeviceSelector extends React.Component {
-    /**
-     * React lifecycle method that is invoked before the component
-     * renders.
-     *
-     * @param {object} nextProps Props that will be used for the next render.
-     * @returns {void}
-     */
-    componentWillReceiveProps(nextProps) {
-        const isExpanding = !this.props.isExpanded && nextProps.isExpanded;
-        if (isExpanding) {
-            this.focusDropdownButton();
-        }
-    }
-
+export default class DeviceSelector extends AbstractSelector {
     /**
      * Returns the JSX that corresponds to a "Close device" menu item.
      * If no device is selected, then no close item is rendered.
@@ -115,23 +103,6 @@ export default class DeviceSelector extends React.Component {
                 </ul>
             </MenuItem>
         );
-    }
-
-    /**
-     * Focuses the selector dropdown button. This is needed to make the
-     * up/down arrow keys work when the selector is expanded.
-     *
-     * @returns {void}
-     */
-    focusDropdownButton() {
-        // eslint-disable-next-line react/no-find-dom-node
-        const node = ReactDOM.findDOMNode(this);
-        if (node) {
-            const button = node.querySelector('button');
-            if (button) {
-                button.focus();
-            }
-        }
     }
 
     /*

--- a/lib/windows/app/components/SerialPortSelector.jsx
+++ b/lib/windows/app/components/SerialPortSelector.jsx
@@ -35,12 +35,14 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+// import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import DropdownToggle from 'react-bootstrap/lib/DropdownToggle';
 import DropdownMenu from 'react-bootstrap/lib/DropdownMenu';
 import { Iterable } from 'immutable';
+
+import AbstractSelector from './AbstractSelector';
 
 const SEGGER_VENDOR_IDS = new Set(['0x1366', '1366']);
 
@@ -48,33 +50,7 @@ function filterSeggerPorts(port) {
     return SEGGER_VENDOR_IDS.has(port.vendorId);
 }
 
-class SerialPortSelector extends React.Component {
-    componentDidMount() {
-        const {
-            bindHotkey,
-            toggleExpanded,
-            hotkeyExpand,
-        } = this.props;
-
-        bindHotkey(hotkeyExpand.toLowerCase(), () => {
-            // Focusing the dropdown button, so that up/down arrow keys
-            // can be used to select serial port.
-            this.focusDropdownButton();
-            toggleExpanded();
-        });
-    }
-
-    focusDropdownButton() {
-        // eslint-disable-next-line react/no-find-dom-node
-        const node = ReactDOM.findDOMNode(this);
-        if (node) {
-            const button = node.querySelector('button');
-            if (button) {
-                button.focus();
-            }
-        }
-    }
-
+class SerialPortSelector extends AbstractSelector {
     renderSerialPortItems() {
         const {
             ports,
@@ -130,7 +106,7 @@ class SerialPortSelector extends React.Component {
             selectedPort,
             showPortIndicator,
             portIndicatorStatus,
-            toggleExpanded,
+            onToggle,
             isExpanded,
             hotkeyExpand,
             cssClass,
@@ -144,7 +120,7 @@ class SerialPortSelector extends React.Component {
         return (
             <span title={`Select serial port (${hotkeyExpand})`}>
                 <div className={cssClass}>
-                    <Dropdown id="serial-port-selector" open={isExpanded} onToggle={toggleExpanded}>
+                    <Dropdown id="serial-port-selector" open={isExpanded} onToggle={onToggle}>
                         <DropdownToggle
                             className={dropdownCssClass}
                             title={selectorText}
@@ -176,7 +152,7 @@ SerialPortSelector.propTypes = {
     portIndicatorStatus: PropTypes.string,
     isLoading: PropTypes.bool,
     isExpanded: PropTypes.bool,
-    toggleExpanded: PropTypes.func.isRequired,
+    onToggle: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired,
     onDeselect: PropTypes.func.isRequired,
     bindHotkey: PropTypes.func.isRequired,

--- a/lib/windows/app/containers/DeviceSelectorContainer.jsx
+++ b/lib/windows/app/containers/DeviceSelectorContainer.jsx
@@ -112,13 +112,6 @@ class DeviceSelectorContainer extends React.Component {
         this.deviceLister.start();
     }
 
-    componentDidMount() {
-        this.props.bindHotkey('alt+p', () => {
-            this.onToggle();
-        });
-    }
-
-
     /*
      * Called from the templated selector.
      * Shall receive a device definition.
@@ -186,7 +179,7 @@ class DeviceSelectorContainer extends React.Component {
 DeviceSelectorContainer.propTypes = {
     onSelect: PropTypes.func.isRequired,
     onDeselect: PropTypes.func.isRequired,
-    bindHotkey: PropTypes.func.isRequired,
+//    bindHotkey: PropTypes.func.isRequired,
     traits: PropTypes.shape({}),
 };
 

--- a/lib/windows/app/containers/SerialPortSelectorContainer.js
+++ b/lib/windows/app/containers/SerialPortSelectorContainer.js
@@ -54,7 +54,7 @@ function mapDispatchToProps(dispatch) {
     return {
         onSelect: port => dispatch(SerialPortActions.selectPort(port)),
         onDeselect: () => dispatch(SerialPortActions.deselectPort()),
-        toggleExpanded: () => dispatch(SerialPortActions.toggleSelectorExpanded()),
+        onToggle: () => dispatch(SerialPortActions.toggleSelectorExpanded()),
     };
 }
 


### PR DESCRIPTION
This takes the "focus device selector on both hotkeys and click" functionality introduced in https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/174/commits/f5d84d76e34657a3d193aa140b89dc924bff6c86 , and abstracts it away from both the (new) device selector and the (old) serial port selector.

Given that both selectors use exactly the same code for their `focusDropdownButton` method, it makes a lot of sense to have that code in only one place.

This approach aims for the least code changes required for such a refactor.

Note that this pull req targets the `device-selector` branch, not `master`.