### PR TITLE
Abstract the "focus selector on hotkey" logic, wrapper approach

### DIFF
--- a/lib/util/withDropdownFocus.jsx
+++ b/lib/util/withDropdownFocus.jsx
@@ -57,7 +57,7 @@ export default ComposedComponent => {
                     focus={this.focus}
                     isExpanded={this.state.isExpanded}
                     {...this.props}
-                    onToggle={()=>{this.onToggle()}}
+                    onToggle={() => { this.onToggle(); }}
                 />
             );
         }

--- a/lib/util/withDropdownFocus.jsx
+++ b/lib/util/withDropdownFocus.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+export default ComposedComponent => {
+    class WithDropdownFocus extends React.Component {
+        constructor(props) {
+            super(props);
+
+            this.state = {
+                isExpanded: false,
+            };
+        }
+
+        componentDidMount() {
+            this.props.bindHotkey('alt+p', () => {
+                this.onToggle();
+            });
+        }
+
+//         /*
+//         * React lifecycle method that is invoked before the component
+//         * renders.
+//         *
+//         * @param {object} nextProps Props that will be used for the next render.
+//         * @returns {void}
+//         */
+        componentWillUpdate(nextProps, nextState) {
+            const isExpanding = !this.state.isExpanded && nextState.isExpanded;
+            if (isExpanding) {
+                // Focusing the dropdown button, so that up/down arrow keys
+                // can be used to select serial port.
+                this.focus();
+            }
+        }
+
+        onToggle() {
+            console.log('WithDropdownFocus - onToggle()');
+            this.setState(prev => ({ ...prev, isExpanded: !prev.isExpanded }));
+            this.props.onToggle();
+        }
+
+        focus() {
+            // eslint-disable-next-line react/no-find-dom-node
+            const node = ReactDOM.findDOMNode(this);
+            if (node) {
+                const button = node.querySelector('button');
+                if (button) {
+                    button.focus();
+                }
+            }
+        }
+
+        render() {
+            return (
+                <ComposedComponent
+                    focus={this.focus}
+                    isExpanded={this.state.isExpanded}
+                    {...this.props}
+                    onToggle={()=>{this.onToggle()}}
+                />
+            );
+        }
+    }
+
+    WithDropdownFocus.propTypes = {
+        bindHotkey: PropTypes.func.isRequired,
+//         isExpanded: PropTypes.bool,
+        onToggle: PropTypes.func,
+    };
+
+    WithDropdownFocus.defaultProps = {
+//         isExpanded: false,
+        onToggle: () => {},
+    };
+
+    return WithDropdownFocus;
+};

--- a/lib/util/withDropdownFocus.jsx
+++ b/lib/util/withDropdownFocus.jsx
@@ -18,13 +18,8 @@ export default ComposedComponent => {
             });
         }
 
-//         /*
-//         * React lifecycle method that is invoked before the component
-//         * renders.
-//         *
-//         * @param {object} nextProps Props that will be used for the next render.
-//         * @returns {void}
-//         */
+        // React lifecycle method, called when either the props or state is
+        // about to change
         componentWillUpdate(nextProps, nextState) {
             const isExpanding = !this.state.isExpanded && nextState.isExpanded;
             if (isExpanding) {
@@ -35,7 +30,6 @@ export default ComposedComponent => {
         }
 
         onToggle() {
-            console.log('WithDropdownFocus - onToggle()');
             this.setState(prev => ({ ...prev, isExpanded: !prev.isExpanded }));
             this.props.onToggle();
         }
@@ -65,12 +59,10 @@ export default ComposedComponent => {
 
     WithDropdownFocus.propTypes = {
         bindHotkey: PropTypes.func.isRequired,
-//         isExpanded: PropTypes.bool,
         onToggle: PropTypes.func,
     };
 
     WithDropdownFocus.defaultProps = {
-//         isExpanded: false,
         onToggle: () => {},
     };
 

--- a/lib/windows/app/components/DeviceSelector.jsx
+++ b/lib/windows/app/components/DeviceSelector.jsx
@@ -35,7 +35,7 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+// import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import DropdownToggle from 'react-bootstrap/lib/DropdownToggle';
@@ -44,20 +44,6 @@ import DropdownMenu from 'react-bootstrap/lib/DropdownMenu';
 
 // Stateless, templating-only component. Used only from ../containers/DeviceSelectorContainer
 export default class DeviceSelector extends React.Component {
-    /**
-     * React lifecycle method that is invoked before the component
-     * renders.
-     *
-     * @param {object} nextProps Props that will be used for the next render.
-     * @returns {void}
-     */
-    componentWillReceiveProps(nextProps) {
-        const isExpanding = !this.props.isExpanded && nextProps.isExpanded;
-        if (isExpanding) {
-            this.focusDropdownButton();
-        }
-    }
-
     /**
      * Returns the JSX that corresponds to a "Close device" menu item.
      * If no device is selected, then no close item is rendered.
@@ -115,23 +101,6 @@ export default class DeviceSelector extends React.Component {
                 </ul>
             </MenuItem>
         );
-    }
-
-    /**
-     * Focuses the selector dropdown button. This is needed to make the
-     * up/down arrow keys work when the selector is expanded.
-     *
-     * @returns {void}
-     */
-    focusDropdownButton() {
-        // eslint-disable-next-line react/no-find-dom-node
-        const node = ReactDOM.findDOMNode(this);
-        if (node) {
-            const button = node.querySelector('button');
-            if (button) {
-                button.focus();
-            }
-        }
     }
 
     /*

--- a/lib/windows/app/components/SerialPortSelector.jsx
+++ b/lib/windows/app/components/SerialPortSelector.jsx
@@ -35,7 +35,7 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+// import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import DropdownToggle from 'react-bootstrap/lib/DropdownToggle';
@@ -49,32 +49,6 @@ function filterSeggerPorts(port) {
 }
 
 class SerialPortSelector extends React.Component {
-    componentDidMount() {
-        const {
-            bindHotkey,
-            toggleExpanded,
-            hotkeyExpand,
-        } = this.props;
-
-        bindHotkey(hotkeyExpand.toLowerCase(), () => {
-            // Focusing the dropdown button, so that up/down arrow keys
-            // can be used to select serial port.
-            this.focusDropdownButton();
-            toggleExpanded();
-        });
-    }
-
-    focusDropdownButton() {
-        // eslint-disable-next-line react/no-find-dom-node
-        const node = ReactDOM.findDOMNode(this);
-        if (node) {
-            const button = node.querySelector('button');
-            if (button) {
-                button.focus();
-            }
-        }
-    }
-
     renderSerialPortItems() {
         const {
             ports,
@@ -130,7 +104,7 @@ class SerialPortSelector extends React.Component {
             selectedPort,
             showPortIndicator,
             portIndicatorStatus,
-            toggleExpanded,
+            onToggle,
             isExpanded,
             hotkeyExpand,
             cssClass,
@@ -144,7 +118,7 @@ class SerialPortSelector extends React.Component {
         return (
             <span title={`Select serial port (${hotkeyExpand})`}>
                 <div className={cssClass}>
-                    <Dropdown id="serial-port-selector" open={isExpanded} onToggle={toggleExpanded}>
+                    <Dropdown id="serial-port-selector" open={isExpanded} onToggle={onToggle}>
                         <DropdownToggle
                             className={dropdownCssClass}
                             title={selectorText}
@@ -176,10 +150,9 @@ SerialPortSelector.propTypes = {
     portIndicatorStatus: PropTypes.string,
     isLoading: PropTypes.bool,
     isExpanded: PropTypes.bool,
-    toggleExpanded: PropTypes.func.isRequired,
+    onToggle: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired,
     onDeselect: PropTypes.func.isRequired,
-    bindHotkey: PropTypes.func.isRequired,
     hotkeyExpand: PropTypes.string,
     cssClass: PropTypes.string,
     dropdownCssClass: PropTypes.string,

--- a/lib/windows/app/containers/DeviceSelectorContainer.jsx
+++ b/lib/windows/app/containers/DeviceSelectorContainer.jsx
@@ -43,6 +43,7 @@ import DeviceSelector from '../components/DeviceSelector';
 import { connect } from '../../../util/apps';
 import { logger } from '../../../api/logging';
 import withHotkey from '../../../util/withHotkey';
+import withDropdownFocus from '../../../util/withDropdownFocus';
 
 /*
  * Stateful device selector.
@@ -78,7 +79,6 @@ class DeviceSelectorContainer extends React.Component {
         this.state = {
             devices: [],
             selectedSerialNumber: undefined,
-            isExpanded: false,
         };
 
         this.deviceLister.on('conflated', devices => {
@@ -112,13 +112,6 @@ class DeviceSelectorContainer extends React.Component {
         this.deviceLister.start();
     }
 
-    componentDidMount() {
-        this.props.bindHotkey('alt+p', () => {
-            this.onToggle();
-        });
-    }
-
-
     /*
      * Called from the templated selector.
      * Shall receive a device definition.
@@ -145,10 +138,6 @@ class DeviceSelectorContainer extends React.Component {
         this.props.onDeselect();
     }
 
-    onToggle() {
-        this.setState(prev => ({ ...prev, isExpanded: !prev.isExpanded }));
-    }
-
     /*
      * Returns the JSX corresponding to a drop-down menu.
      * Prepares some properties for the template, uses it.
@@ -173,8 +162,8 @@ class DeviceSelectorContainer extends React.Component {
             devices,
             onSelect: device => { this.onSelect(device); },
             onDeselect: () => { this.onDeselect(); },
-            onToggle: () => { this.onToggle(); },
-            isExpanded: this.state.isExpanded,
+            onToggle: this.props.onToggle,
+            isExpanded: this.props.isExpanded,
         };
 
         return (
@@ -186,8 +175,9 @@ class DeviceSelectorContainer extends React.Component {
 DeviceSelectorContainer.propTypes = {
     onSelect: PropTypes.func.isRequired,
     onDeselect: PropTypes.func.isRequired,
-    bindHotkey: PropTypes.func.isRequired,
     traits: PropTypes.shape({}),
+    onToggle: PropTypes.func.isRequired,
+    isExpanded: PropTypes.bool.isRequired,
 };
 
 DeviceSelectorContainer.defaultProps = {
@@ -211,4 +201,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
     args => args,
     mapDispatchToProps,
-)(withHotkey(DeviceSelectorContainer), 'DeviceSelector');
+)(withHotkey(withDropdownFocus(DeviceSelectorContainer)), 'DeviceSelector');

--- a/lib/windows/app/containers/SerialPortSelectorContainer.js
+++ b/lib/windows/app/containers/SerialPortSelectorContainer.js
@@ -37,6 +37,7 @@
 import SerialPortSelector from '../components/SerialPortSelector';
 import * as SerialPortActions from '../actions/serialPortActions';
 import withHotkey from '../../../util/withHotkey';
+import withDropdownFocus from '../../../util/withDropdownFocus';
 import { connect } from '../../../util/apps';
 
 function mapStateToProps(state) {
@@ -54,11 +55,11 @@ function mapDispatchToProps(dispatch) {
     return {
         onSelect: port => dispatch(SerialPortActions.selectPort(port)),
         onDeselect: () => dispatch(SerialPortActions.deselectPort()),
-        toggleExpanded: () => dispatch(SerialPortActions.toggleSelectorExpanded()),
+        onToggle: () => dispatch(SerialPortActions.toggleSelectorExpanded()),
     };
 }
 
 export default connect(
     mapStateToProps,
     mapDispatchToProps,
-)(withHotkey(SerialPortSelector), 'SerialPortSelector');
+)(withHotkey(withDropdownFocus(SerialPortSelector)), 'SerialPortSelector');


### PR DESCRIPTION
This takes the "focus device selector on both hotkeys and click" functionality introduced in https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/174/commits/f5d84d76e34657a3d193aa140b89dc924bff6c86 , and abstracts it away from both the (new) device selector and the (old) serial port selector.

Given that both selectors use exactly the same code for their `focusDropdownButton` method, it makes a lot of sense to have that code in only one place.

This approach aims for the least code changes required for such a refactor, while forcing myself to implement a component wrapper AKA "higher-order component".

Because the prop updates only go down, the management of the `isExpanded` prop is hoisted up to the wrapper. I couldn't find a clean way to implement **just** the `focusDropdownButton` logic by using wrappers.

Note that this pull req targets the `device-selector` branch, not `master`.