### PR TITLE
Add function for getting the config object from apps

### DIFF
--- a/lib/util/apps.js
+++ b/lib/util/apps.js
@@ -136,6 +136,15 @@ function getAppLogDir() {
 }
 
 /**
+ * Get app config object. Will be an empty object if the app does not specify this.
+ *
+ * @returns {Object} The config object given by the app.
+ */
+function getAppConfig() {
+    return app.config || {};
+}
+
+/**
  * Invokes a function optionally defined by the loaded app.
  *
  * @param {string} name name of function
@@ -290,6 +299,7 @@ export default {
     getAppDir,
     getAppDataDir,
     getAppLogDir,
+    getAppConfig,
     getUserDataDir,
     invokeAppFn,
 };

--- a/lib/windows/app/components/NavBar.jsx
+++ b/lib/windows/app/components/NavBar.jsx
@@ -41,21 +41,21 @@ import DeviceSelectorContainer from '../containers/DeviceSelectorContainer';
 import SerialPortSelectorContainer from '../containers/SerialPortSelectorContainer';
 import NavMenuContainer from '../containers/NavMenuContainer';
 import MainMenuContainer from '../containers/MainMenuContainer';
-import { decorate } from '../../../util/apps';
+import { decorate, getAppConfig } from '../../../util/apps';
 
 const DecoratedLogo = decorate(Logo, 'Logo');
 
 function NavBar({
         cssClass,
         navSectionCssClass,
-        selectorTraits,
     }) {
+    const appConfig = getAppConfig();
     return (
         <div className={cssClass}>
             <MainMenuContainer />
             <div className={navSectionCssClass}>
-                { selectorTraits ?
-                    <DeviceSelectorContainer traits={selectorTraits} /> :
+                { appConfig.selectorTraits ?
+                    <DeviceSelectorContainer traits={appConfig.selectorTraits} /> :
                     <SerialPortSelectorContainer />
                 }
             </div>
@@ -68,13 +68,11 @@ function NavBar({
 NavBar.propTypes = {
     cssClass: PropTypes.string,
     navSectionCssClass: PropTypes.string,
-    selectorTraits: PropTypes.shape({}),
 };
 
 NavBar.defaultProps = {
     cssClass: 'core-nav-bar',
     navSectionCssClass: 'core-nav-section core-padded-row',
-    selectorTraits: undefined,
 };
 
 export default NavBar;

--- a/lib/windows/app/components/Root.jsx
+++ b/lib/windows/app/components/Root.jsx
@@ -35,7 +35,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import NavBar from './NavBar';
 import SidePanelContainer from '../containers/SidePanelContainer';
 import LogViewerContainer from '../containers/LogViewerContainer';
@@ -46,9 +45,9 @@ import { decorate } from '../../../util/apps';
 
 const DecoratedNavBar = decorate(NavBar, 'NavBar');
 
-const Root = ({ selectorTraits }) => (
+const Root = () => (
     <div className="core-main-area">
-        <DecoratedNavBar selectorTraits={selectorTraits} />
+        <DecoratedNavBar />
         <div className="core-main-layout">
             <div>
                 <MainViewContainer />
@@ -60,13 +59,5 @@ const Root = ({ selectorTraits }) => (
         <ErrorDialogContainer />
     </div>
 );
-
-Root.propTypes = {
-    selectorTraits: PropTypes.shape({}),
-};
-
-Root.defaultProps = {
-    selectorTraits: undefined,
-};
 
 export default Root;

--- a/lib/windows/app/containers/RootContainer.js
+++ b/lib/windows/app/containers/RootContainer.js
@@ -39,21 +39,12 @@ import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import Root from '../components/Root';
 
-const RootContainer = ({ store, selectorTraits }) => (
-    React.createElement(
-        Provider,
-        { store },
-        React.createElement(Root, { selectorTraits }),
-    )
+const RootContainer = ({ store }) => (
+    React.createElement(Provider, { store }, React.createElement(Root))
 );
 
 RootContainer.propTypes = {
     store: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-    selectorTraits: PropTypes.shape({}),
-};
-
-RootContainer.defaultProps = {
-    selectorTraits: undefined,
 };
 
 export default RootContainer;

--- a/lib/windows/app/index.js
+++ b/lib/windows/app/index.js
@@ -98,11 +98,7 @@ initAppDirectories(appPath).then(() => {
         }
     };
 
-    const config = app.config || {};
-    const selectorTraits = config.selectorTraits;
-    const rootElement = React.createElement(RootContainer, {
-        store, selectorTraits,
-    });
+    const rootElement = React.createElement(RootContainer, { store });
     render(rootElement, document.getElementById('webapp'), () => {
         removeLoaderElement();
         invokeAppFn('onReady', store.dispatch, store.getState);


### PR DESCRIPTION
Adding a `getAppConfig()` function to make it easy to access the `config` object defined by apps.

Currently, this object is only used for defining traits for the device selector, but the plan is that apps can also put firmware configuration in the `config`.