### PR TITLE
Feature/device programming choices

### DIFF
--- a/lib/windows/app/actions/deviceActions.js
+++ b/lib/windows/app/actions/deviceActions.js
@@ -192,6 +192,21 @@ function deviceSetupConfirmationReceivedAction(choice) {
     };
 }
 
+function deviceSetupChoiceRequiredAction(message, choices) {
+    return {
+        type: DEVICE_SETUP_CHOICE_REQUIRED,
+        message,
+        choices,
+    };
+}
+
+function deviceSetupChoiceReceivedAction(choice) {
+    return {
+        type: DEVICE_SETUP_CHOICE_RECEIVED,
+        choice,
+    };
+}
+
 /**
  * Deselects the currently selected device.
  *
@@ -282,7 +297,7 @@ export function selectAndSetupDevice(device) {
                             reject(new Error('Cancelled by user.'));
                         }
                     };
-                    dispatch(deviceSetupConfirmationRequiredAction(message, choices));
+                    dispatch(deviceSetupChoiceRequiredAction(message, choices));
                 });
             }
 
@@ -312,6 +327,24 @@ export function deviceSetupConfirmationReceived(choice) {
             deviceSetupCallback = undefined;
         } else {
             logger.error('Received a device setup confirmation, but no callback exists.');
+        }
+    };
+}
+
+/**
+ * Responds to a device setup choice request with the given choice.
+ *
+ * @param {Boolean|String} choice The choice made by the user.
+ * @returns {function(*)} Function that can be passed to redux dispatch.
+ */
+export function deviceSetupChoiceReceived(choice) {
+    return dispatch => {
+        dispatch(deviceSetupChoiceReceivedAction(choice));
+        if (deviceSetupCallback) {
+            deviceSetupCallback(choice);
+            deviceSetupCallback = undefined;
+        } else {
+            logger.error('Received a device setup choice, but no callback exists.');
         }
     };
 }

--- a/lib/windows/app/components/DeviceSetupDialog.jsx
+++ b/lib/windows/app/components/DeviceSetupDialog.jsx
@@ -36,24 +36,51 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { MenuItem } from 'react-bootstrap';
+import { Iterable } from 'immutable';
 
 import ConfirmationDialog from '../../../components/ConfirmationDialog';
 
 const DeviceSetupDialog = ({
     isVisible,
     text,
+    choices,
+    onChoose,
     onConfirm,
     onCancel,
+    menuItemCssClass,
 }) => {
     if (isVisible) {
+        if (choices.length > 0 || (choices.count && choices.count() > 0)) {
+            const renderChoices = () => choices.map(choice => (
+                <MenuItem
+                    key={choice}
+                    className={menuItemCssClass}
+                    eventKey={choice}
+                    onSelect={() => onChoose(choice)}
+                >
+                    <div>{choice}</div>
+                </MenuItem>
+            ));
+            return (
+                <ConfirmationDialog
+                    isVisible={isVisible}
+                    okButtonText={'Cancel'}
+                    onOk={onCancel}
+                >
+                    <p>{ text }</p>
+                    <ul>{ renderChoices() }</ul>
+                </ConfirmationDialog>
+            );
+        }
         return (
             <ConfirmationDialog
                 isVisible={isVisible}
-                text={text}
                 okButtonText={'Yes'}
                 cancelButtonText={'No'}
-                onOk={() => onConfirm(true)}
+                onOk={onConfirm}
                 onCancel={onCancel}
+                text={text}
             />
         );
     }
@@ -63,12 +90,19 @@ const DeviceSetupDialog = ({
 DeviceSetupDialog.propTypes = {
     isVisible: PropTypes.bool.isRequired,
     text: PropTypes.string,
+    choices: PropTypes.oneOfType([
+        PropTypes.instanceOf(Array),
+        PropTypes.instanceOf(Iterable),
+    ]).isRequired,
+    onChoose: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    menuItemCssClass: PropTypes.string,
 };
 
 DeviceSetupDialog.defaultProps = {
     text: '',
+    menuItemCssClass: 'device-setup-list-item',
 };
 
 export default DeviceSetupDialog;

--- a/lib/windows/app/containers/DeviceSetupContainer.js
+++ b/lib/windows/app/containers/DeviceSetupContainer.js
@@ -44,13 +44,14 @@ function mapStateToProps(state) {
     return {
         isVisible: device.isSetupDialogVisible,
         text: device.setupDialogText,
-        setupDialogChoices: device.setupDialogChoices,
+        choices: device.setupDialogChoices,
     };
 }
 
 function mapDispatchToProps(dispatch) {
     return {
-        onConfirm: choice => dispatch(DeviceActions.deviceSetupConfirmationReceived(choice)),
+        onChoose: choice => dispatch(DeviceActions.deviceSetupChoiceReceived(choice)),
+        onConfirm: () => dispatch(DeviceActions.deviceSetupConfirmationReceived(true)),
         onCancel: () => dispatch(DeviceActions.deviceSetupConfirmationReceived(false)),
     };
 }

--- a/resources/css/app.less
+++ b/resources/css/app.less
@@ -172,3 +172,16 @@ ul.core-device-selector-item-details {
         padding: 6px 6px 6px 0px;
     }
 }
+
+.device-setup-list-item {
+    display: list-item;
+    list-style-type: none;
+    line-height: 2em;
+    a {
+        text-decoration: none;
+    }
+}
+
+.device-setup-list-item:hover {
+    list-style-type: disc;
+}


### PR DESCRIPTION
Extended device setup dialog for making a choice from a list.

Didn't commit package.json, that should be solved on parent branch, locally I have copied `nrf-device-actions-js` and `nrf-device-lister-js`, and:

`npm i await-semaphore nrf-intel-hex pc-nrf-dfu-js protobuf-js`

RSSI app with related modifications: https://github.com/NordicSemiconductor/pc-nrfconnect-rssi/tree/device-actions