### PR TITLE
Log lister errors to file instead of log viewer

### DIFF
--- a/lib/windows/app/actions/deviceActions.js
+++ b/lib/windows/app/actions/deviceActions.js
@@ -168,9 +168,9 @@ function logDeviceListerError(error) {
             message += 'Please check that a libusb-compatible kernel driver is bound to this device.';
         }
 
-        logger.error(message);
+        logger.debug(message);
     } else {
-        logger.error(`Error while probing devices: ${error.message}`);
+        logger.debug(`Error while probing devices: ${error.message}`);
     }
 }
 


### PR DESCRIPTION
The nrf-device-lister outputs a lot of errors, even in cases where there are no problems. It tries to get serial numbers from a lot of devices, and many will fail, and that is to be expected.

Proposing to log the errors with `debug` level instead, so that these errors end up in the log file. This way they are less intrusive. The drawback is of course that some users may miss out on important errors.

@bencefr @IvanSanchez Opinions?