### PR TITLE
Add pc-nrfconnect-programmer to apps.json

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -18,5 +18,10 @@
         "displayName": "Power Profiler",
         "description": "Tool to measure current for nRF5x applications",
         "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-ppk"
+    },
+    "pc-nrfconnect-programmer": {
+        "displayName": "nRF Programmer",
+        "description": "Tool for flash programming of nRF5x SoCs",
+        "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-programmer"
     }
 }


### PR DESCRIPTION
This will make the programmer app available in nRF Connect. Please verify that the name and description is as expected.

The app repository is still not public, so the "More information" link does not work at the moment. We should perhaps make the repo public before making the app available?