### PR TITLE
Add libgconf-2-4 as required package for building on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The project depends on [pc-ble-driver-js](https://github.com/NordicSemiconductor
 
 Install packages required for building the project on Ubuntu Linux:
 
-    apt-get install build-essential python2.7 libudev-dev
+    apt-get install build-essential python2.7 libudev-dev libgconf-2-4
 
 ### Windows
 


### PR DESCRIPTION
I got an error regarding missing libgconf-2-4 when running electron on a freshly installed Ubuntu 18.04. The latest nRF Connect AppImage seems to work fine without it, as it exists in `/usr/lib` that is mounted by the AppImage:

```
$ find /tmp/.mount_nrfconwjwJPj -name "libgconf*"
/tmp/.mount_nrfconwjwJPj/usr/lib/libgconf-2.so.4
```

So considering this only as a requirement for development.