### PR TITLE
Upgrade to Electron v1.8

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
-target = 1.6.16
+target = 1.8.7
 disturl = https://atom.io/download/atom-shell

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.4.0-alpha.1",
+    "version": "2.4.0-alpha.2",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "asar": "0.13.0",
         "babel-polyfill": "6.23.0",
         "bootstrap": "3.3.7",
-        "electron": "1.6.16",
+        "electron": "1.8.7",
         "electron-builder": "19.53.6",
         "electron-is-dev": "0.1.2",
         "moment": "2.18.1",


### PR DESCRIPTION
Upgrading now because Electron v1.6 is not rendering text properly on Ubuntu 18.04. There is a text rendering issue with Electron in combination with freetype v2.8.1, which is installed by default on Ubuntu 18.04. The issue has been fixed in Electron >=v1.7, but it has not been backported to v1.6.

I have done some smoke testing on Ubuntu 16.04 and 18.04, and have not seen any problems yet. More thorough testing on all platforms will be done as part of the v2.4.0 release testing.