### PR TITLE
Use yarn registry for tarball downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.4.0-alpha.1",
+    "version": "2.3.1",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Over the weekend, npm have made some changes to the way they serve registry data, ref. https://status.npmjs.org/incidents/t3j62lxb7jg3. This seems to have had an effect on nRF Connect, because downloading app tarballs now fail with a 503 status code.

I have done some debugging, and it seems to happen only when accessing the npm registry through the Electron net API. The Node.js https module works as expected, and accessing the registry through a normal web browser also works. We need to investigate a bit more to pinpoint the issue.

Yarn's registry URL still works fine when accessed from nRF Connect. The tarballs are available from there as well, so we can replace registry.npmjs.org with registry.yarnpkg.com, at least as a short-term fix.