### PR TITLE
nrf-device-setup dependency updated to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "fs-extra": "4.0.1",
         "mustache": "2.3.0",
         "nrf-device-lister": "2.0.0",
-        "nrf-device-setup": "0.2.3",
+        "nrf-device-setup": "0.2.5",
         "pc-ble-driver-js": "github:NordicSemiconductor/pc-ble-driver-js#master",
         "pc-nrfjprog-js": "1.2.0",
         "png2icons": "0.9.1",


### PR DESCRIPTION
The updated dependency has timeout changes and logger/debug fixes.