### PR TITLE
Use developer.nordicsemi.com as app registry

### DIFF
--- a/main/config.js
+++ b/main/config.js
@@ -97,7 +97,7 @@ function init(argv) {
     appsJsonPath = path.join(appsRootDir, 'apps.json');
     settingsJsonPath = argv['settings-json-path'] || path.join(userDataDir, 'settings.json');
     appsJsonUrl = 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfconnect-core/master/apps.json';
-    registryUrl = 'https://registry.yarnpkg.com';
+    registryUrl = 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/';
     releaseNotesUrl = 'https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases';
     skipUpdateApps = argv['skip-update-apps'] || false;
     skipUpdateCore = argv['skip-update-core'] || false;


### PR DESCRIPTION
There is a problem with the electron net API and accessing the npm/yarn registries, so we fetch app information from developer.nordicsemi.com until a fix is in place.

This has already been released from the release/2.3 branch and tagged with v2.3.2. Cherry-picking the commit to include it on master as well.