### PR TITLE
Update nrf-device-setup version

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "fs-extra": "4.0.1",
         "mustache": "2.3.0",
         "nrf-device-lister": "2.0.0",
-        "nrf-device-setup": "0.2.5",
+        "nrf-device-setup": "0.2.6",
         "pc-ble-driver-js": "2.4.1",
         "pc-nrfjprog-js": "1.2.0",
         "png2icons": "0.9.1",


### PR DESCRIPTION
This PR update the version of nrf-device-setup in order to fix dfu bug on MacOS.