### PR TITLE
Include nrfjprog v9.7.3

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -30,7 +30,7 @@
 
   ; The version of the bundled nRF5x-Command-Line-Tools
   Var /GLOBAL BUNDLED_NRFJPROG_VERSION
-  StrCpy $BUNDLED_NRFJPROG_VERSION "9.7.1"
+  StrCpy $BUNDLED_NRFJPROG_VERSION "9.7.3"
 
   ; Adding nRF5x-Command-Line-Tools installer (downloaded by 'npm run get-nrfjprog')
   File "${BUILD_RESOURCES_DIR}\nrfjprog\nrfjprog-win32.exe"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
             ],
             "extraFiles": [
                 {
-                    "from": "build/nrfjprog/unpacked/nrfjprog",
+                    "from": "node_modules/pc-nrfjprog-js/nrfjprog/lib",
                     "to": ".",
                     "filter": "*.so*"
                 }
@@ -69,7 +69,7 @@
             "artifactName": "${name}-${version}-${os}.${ext}",
             "extraFiles": [
                 {
-                    "from": "build/nrfjprog/unpacked/nrfjprog",
+                    "from": "node_modules/pc-nrfjprog-js/nrfjprog/lib",
                     "to": "Frameworks",
                     "filter": "*.dylib"
                 }

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "nrf-device-lister": "2.0.0",
         "nrf-device-setup": "0.2.6",
         "pc-ble-driver-js": "2.4.1",
-        "pc-nrfjprog-js": "1.2.0",
+        "pc-nrfjprog-js": "1.3.1",
         "png2icons": "0.9.1",
         "semver": "5.3.0",
         "serialport": "6.2.0",


### PR DESCRIPTION
This PR updates the dependency of pc-nrfjprog-js to v1.3.1 which includes nrfjprog 9.7.3.
Download URL has been updated to nrfjprog installer which still needs to be bundled with nRFConnect installer.