### PR TITLE
Serial troubleshooting doc: remove another bit about dongle reset-while-plug-in

### DIFF
--- a/doc/serial-timeout-troubleshoot.md
+++ b/doc/serial-timeout-troubleshoot.md
@@ -48,10 +48,7 @@ serial port, but is not understanding it, and it's not replying to it.
 Ensure that the devkit/dongle is in bootloader mode.
 
 - For nRF52840 dongles:
-    - Unplug it from its USB port.
-    - Hold down the reset button.
-    - Plug the dongle into a USB port. The red LED should be pulsing, indicating the nRF device is in DFU bootloader mode.
-    - Stop holding down the reset button.
+    - Press the reset button. The red LED should be pulsing, indicating the nRF device is in DFU bootloader mode.
     - Perform the DFU operation again.
 
 - For nRF52840 development kits:


### PR DESCRIPTION
Same as https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/221/commits/011188f87c0a555d1c040b95f5f92f81d298e4cd - only that #221 was merged in without really realizing that change had to be made twice, one per each troubleshooting document.