### PR TITLE
Return error object if shasum verification fails

### DIFF
--- a/main/registryApi.js
+++ b/main/registryApi.js
@@ -88,8 +88,8 @@ function verifyShasum(filePath, expectedShasum) {
                 if (expectedShasum === computedShasum) {
                     resolve();
                 } else {
-                    reject(`Shasum verification failed for ${filePath}. Expected ` +
-                        `'${expectedShasum}', but got '${computedShasum}'.`);
+                    reject(new Error(`Shasum verification failed for ${filePath}. Expected ` +
+                        `'${expectedShasum}', but got '${computedShasum}'.`));
                 }
             }
         });


### PR DESCRIPTION
When installing apps, the shasum of the downloaded tarball is compared to the shasum from the npm registry. If the shasum verification fails, an error should be displayed to the user.

The error was however not displayed properly (showed up as `undefined`), because this rejection contained a string instead of an error object.