### PR TITLE
Remove redundant npm registry workaround

### DIFF
--- a/main/registryApi.js
+++ b/main/registryApi.js
@@ -111,12 +111,7 @@ function downloadTarball(name, version, destinationDir) {
             if (!distInfo.tarball) {
                 return Promise.reject(`No tarball found for ${name}@${version}`);
             }
-            // As of late May 2018, the electron net API has started getting 503
-            // errors when trying to access registry.npmjs.org. If the tarball
-            // points to registry.npmjs.org, then we use our configured registry
-            // URL (currently yarn's registry) instead.
-            const tarballUrl = distInfo.tarball.replace('https://registry.npmjs.org',
-                config.getRegistryUrl());
+            const tarballUrl = distInfo.tarball;
             const parsedUrl = url.parse(tarballUrl);
             const fileName = path.basename(parsedUrl.pathname);
             const destinationFile = path.join(destinationDir, fileName);


### PR DESCRIPTION
As we are now fetching apps from developer.nordicsemi.com, this workaround is no longer needed.