### PR TITLE
Disable Cancel button when download is 100% complete

### DIFF
--- a/lib/windows/launcher/components/UpdateProgressDialog.jsx
+++ b/lib/windows/launcher/components/UpdateProgressDialog.jsx
@@ -70,7 +70,12 @@ const UpdateProgressDialog = ({
             }
             {
                 isCancelSupported &&
-                    <Button onClick={onCancel} disabled={isCancelling}>Cancel</Button>
+                    <Button
+                        onClick={onCancel}
+                        disabled={isCancelling || percentDownloaded === 100}
+                    >
+                        Cancel
+                    </Button>
             }
         </ModalFooter>
     </Modal>

--- a/lib/windows/launcher/components/__tests__/UpdateProgressDialog-test.jsx
+++ b/lib/windows/launcher/components/__tests__/UpdateProgressDialog-test.jsx
@@ -107,4 +107,18 @@ describe('UpdateProgressDialog', () => {
             />,
         )).toMatchSnapshot();
     });
+
+    it('should render with cancel disabled when 100 percent complete', () => {
+        expect(renderer.create(
+            <UpdateProgressDialog
+                isVisible
+                isProgressSupported
+                isCancelSupported
+                version="1.2.3"
+                percentDownloaded={100}
+                onCancel={() => {}}
+                isCancelling={false}
+            />,
+        )).toMatchSnapshot();
+    });
 });

--- a/lib/windows/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
@@ -71,6 +71,43 @@ exports[`UpdateProgressDialog should render invisible 1`] = `
 </Modal>
 `;
 
+exports[`UpdateProgressDialog should render with cancel disabled when 100 percent complete 1`] = `
+<Modal
+  backdrop={true}
+  show={true}
+>
+  <ModalHeader
+    closeButton={false}
+  >
+    <ModalTitle>
+      Downloading update
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>
+      Downloading nRF Connect 
+      1.2.3
+      ...
+    </p>
+    <ProgressBar
+      label="100%"
+      now={100}
+    />
+    <p>
+      This might take a few minutes. The application will restart and update once the download is complete.
+    </p>
+  </ModalBody>
+  <ModalFooter>
+    <Button
+      disabled={true}
+      onClick={[Function]}
+    >
+      Cancel
+    </Button>
+  </ModalFooter>
+</Modal>
+`;
+
 exports[`UpdateProgressDialog should render with version, percent downloaded, and cancellable 1`] = `
 <Modal
   backdrop={true}


### PR DESCRIPTION
When clicking Cancel while downloading a new version of nRF Connect, and the download has reached 100%, it does not cancel the operation. The [cancel mechanism in electron-updater](https://github.com/electron-userland/electron-builder/blob/master/docs/auto-update.md#module_electron-updater.AppUpdater+downloadUpdate) is only for cancelling the download operation. Since the download is complete, cancel does not have any effect. Disabling the button in this scenario.