### PR TITLE
Fix problem with upgrading after having cancelled

### DIFF
--- a/lib/windows/launcher/actions/autoUpdateActions.js
+++ b/lib/windows/launcher/actions/autoUpdateActions.js
@@ -48,9 +48,13 @@ export const AUTO_UPDATE_DOWNLOADING = 'AUTO_UPDATE_DOWNLOADING';
 export const AUTO_UPDATE_ERROR = 'AUTO_UPDATE_ERROR';
 
 const { autoUpdater, CancellationToken } = remote.require('./main/autoUpdate');
-const cancellationToken = new CancellationToken();
 const isWindows = process.platform === 'win32';
 const isMac = process.platform === 'darwin';
+
+// This is set and given to electron-updater when starting to download an
+// application update. Will only exist while a download is in progress, and
+// allows cancelling the download by calling cancellationToken.cancel().
+let cancellationToken;
 
 function checkAction() {
     return {
@@ -130,16 +134,26 @@ export function checkForCoreUpdates() {
 
 export function startDownload() {
     return dispatch => {
+        if (cancellationToken) {
+            dispatch(ErrorDialogActions.showDialog('Download was requested ' +
+                'but another download operation is already in progress.'));
+            return;
+        }
+
         dispatch(startDownloadAction());
 
         autoUpdater.on('download-progress', progressObj => {
             dispatch(updateDownloadingAction(progressObj.percent));
         });
+
         autoUpdater.on('update-downloaded', () => {
+            cancellationToken = null;
             autoUpdater.removeAllListeners();
             autoUpdater.quitAndInstall();
         });
+
         autoUpdater.on('error', error => {
+            cancellationToken = null;
             autoUpdater.removeAllListeners();
             if (error.message === 'Cancelled') {
                 dispatch(downloadCancelledAction());
@@ -149,13 +163,19 @@ export function startDownload() {
             }
         });
 
+        cancellationToken = new CancellationToken();
         autoUpdater.downloadUpdate(cancellationToken);
     };
 }
 
 export function cancelDownload() {
     return dispatch => {
-        dispatch(cancelDownloadAction());
-        cancellationToken.cancel();
+        if (cancellationToken) {
+            cancellationToken.cancel();
+            dispatch(cancelDownloadAction());
+        } else {
+            dispatch(ErrorDialogActions.showDialog('Unable to cancel. ' +
+                'No download is in progress.'));
+        }
     };
 }


### PR DESCRIPTION
When starting a download, and cancelling it in the middle of the download process, any subsequent calls to `autoUpdater.downloadUpdate()` failed. This is because the cancellation token from the first download was reused for subsequent downloads. Now creating a new cancellation token for each download.