### PR TITLE
Using error codes from nrf-device-listener-js

### DIFF
--- a/lib/windows/app/actions/deviceActions.js
+++ b/lib/windows/app/actions/deviceActions.js
@@ -165,7 +165,8 @@ function logDeviceListerError(error) {
         // to a libusb-compatible-driver will fail to enumerate and trigger a
         // LIBUSB_* error. This is the case of a nRF52840 in DFU mode.
         // We don't want to show an error to the user in this particular case.
-        if (error.message === 'LIBUSB_ERROR_NOT_FOUND' && error.usb.deviceDescriptor) {
+        // errorCode 105 = LIBUSB_ERROR_NOT_FOUND
+        if (error.errorCode === 105 && error.usb.deviceDescriptor) {
             const { idProduct, idVendor } = error.usb.deviceDescriptor;
             if (idVendor === NORDIC_VENDOR_ID && idProduct === NORDIC_BOOTLOADER_PRODUCT_ID) {
                 return;
@@ -183,8 +184,7 @@ function logDeviceListerError(error) {
         }
 
         logger.error(message);
-    } else if (error.serialport &&
-        error.message.includes('Could not fetch serial number for serial port at')) {
+    } else if (error.serialport && error.errorCode === 3) {
         // Explicitly hide errors about serial ports without serial numbers
         logger.verbose(error.message);
     } else {


### PR DESCRIPTION
Instead of comparing error message strings, every error now has an error code that can be used for comparisons. 

Depending on https://github.com/NordicSemiconductor/nrf-device-lister-js/pull/32