### PR TITLE
Fix device setup dialog resolution

### DIFF
--- a/lib/windows/app/actions/deviceActions.js
+++ b/lib/windows/app/actions/deviceActions.js
@@ -259,7 +259,10 @@ export function stopWatchingDevices() {
 function getDeviceSetupUserInput(dispatch, message, choices = undefined) {
     return new Promise((resolve, reject) => {
         deviceSetupCallback = choice => {
-            if (choice) {
+            if (!choices) {
+                // for confirmation resolve with boolean
+                resolve(!!choice);
+            } else if (choice) {
                 resolve(choice);
             } else {
                 reject(new Error('Cancelled by user.'));

--- a/lib/windows/app/components/DeviceSetupDialog.jsx
+++ b/lib/windows/app/components/DeviceSetupDialog.jsx
@@ -109,7 +109,7 @@ export default class DeviceSetupDialog extends React.Component {
                 okButtonText={'Yes'}
                 cancelButtonText={'No'}
                 onOk={() => onOk(true)}
-                onCancel={onCancel}
+                onCancel={() => onOk(false)}
                 text={text}
             />
         );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ function createExternals() {
         'pc-nrfjprog-js',
         'serialport',
         'usb',
+        'nrf-device-setup',
     ];
     return libs.reduce((prev, lib) => (
         Object.assign(prev, { [lib]: `commonjs ${lib}` })


### PR DESCRIPTION
In order to match expected promise resolution by nrf-device-setup (same resolution as with inquirer) the callback for confirmation is changed to resolve with boolean rather than rejection.
This result is needed to complete bootloader update support by nrf-device-setup, which upon cancelling an update shall not break the opening the device.