### PR TITLE
Remove electron-builder-http dependency

### DIFF
--- a/main/autoUpdate.js
+++ b/main/autoUpdate.js
@@ -36,8 +36,7 @@
 
 'use strict';
 
-const autoUpdater = require('electron-updater').autoUpdater;
-const CancellationToken = require('electron-builder-http/out/CancellationToken').CancellationToken;
+const { autoUpdater, CancellationToken } = require('electron-updater');
 const log = require('electron-log');
 
 autoUpdater.autoDownload = false;

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     },
     "dependencies": {
         "chmodr": "1.0.2",
-        "electron-builder-http": "18.5.1",
         "electron-log": "2.2.6",
         "electron-updater": "2.20.2",
         "fs-extra": "4.0.1",


### PR DESCRIPTION
Previously, the `CancellationToken` was only exposed through electron-builder-http, but with recent versions of electron-updater it is included in the library. This allows us to remove our dependency to electron-builder-http.

I have verified that cancelling the download process during auto update still works as before.