### PR TITLE
Expose start and stop watching devices actions in API

### DIFF
--- a/lib/api/core/index.js
+++ b/lib/api/core/index.js
@@ -41,9 +41,16 @@ import {
     getUserDataDir,
 } from '../../util/apps';
 
+import {
+    startWatchingDevices,
+    stopWatchingDevices,
+} from '../../windows/app/actions/deviceActions';
+
 export default {
     getAppDir,
     getAppDataDir,
     getAppLogDir,
     getUserDataDir,
+    startWatchingDevices,
+    stopWatchingDevices,
 };


### PR DESCRIPTION
There are several use cases when an app interacts with a device in a manner that changes the device or conflicts with current nrfjprog functionality, therefore we need be able to control the _DeviceLister_ instance of core from an app.