### PR TITLE
Add JSX <a> tag around links in log messages

### DIFF
--- a/lib/windows/app/components/LogEntry.jsx
+++ b/lib/windows/app/components/LogEntry.jsx
@@ -67,7 +67,7 @@ function hrefReplacer(str) {
 
 const LogEntry = ({ entry }) => {
     const className = `core-log-entry core-log-level-${entry.level}`;
-    const time = moment(entry.time).format('HH:mm:ss.SSSS');
+    const time = moment(entry.time).format('HH:mm:ss.SSS');
 
     return (
         <div className={className}>

--- a/lib/windows/app/components/LogEntry.jsx
+++ b/lib/windows/app/components/LogEntry.jsx
@@ -38,6 +38,33 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
+const regex = /(.*?)(https?:\/\/[^\s]+)/g;
+
+/**
+ * Convert strings to array of strings and JSX <a> tags for hrefs
+ *
+ * E.g. 'For reference see: https://github.com/example/doc.md or reboot Windows.'
+ * will be converted to:
+ * [
+ *    'For reference see: ',
+ *    <a href='https://github.com/example/doc.md'>https://github.com/example/doc.md</a>,
+ *    ' or reboot Windows.',
+ * ]
+ *
+ * @param {string} str input string
+ * @returns {Array} strings and JSX <a> tags
+ */
+function hrefReplacer(str) {
+    const message = [];
+    const remainder = str.replace(regex, (match, before, href, index) => {
+        message.push(before);
+        message.push(<a key={index} href={href}>{href}</a>);
+        return '';
+    });
+    message.push(remainder);
+    return message;
+}
+
 const LogEntry = ({ entry }) => {
     const className = `core-log-entry core-log-level-${entry.level}`;
     const time = moment(entry.time).format('HH:mm:ss.SSSS');
@@ -45,7 +72,7 @@ const LogEntry = ({ entry }) => {
     return (
         <div className={className}>
             <div className="core-log-time">{time}</div>
-            <div className="core-log-message">{entry.message}</div>
+            <div className="core-log-message">{hrefReplacer(entry.message)}</div>
         </div>
     );
 };

--- a/lib/windows/app/components/__tests__/LogViewer-test.jsx
+++ b/lib/windows/app/components/__tests__/LogViewer-test.jsx
@@ -62,6 +62,11 @@ describe('LogViewer', () => {
                 level: 'error',
                 time: new Date('2017-02-03T13:41:36.020Z'),
                 message: 'Error message',
+            }, {
+                id: 3,
+                level: 'info',
+                time: new Date('2017-02-03T13:41:36.020Z'),
+                message: 'For reference see: https://github.com/example/doc.md or reboot Windows.',
             },
         ]);
         expect(renderer.create(

--- a/lib/windows/app/components/__tests__/__snapshots__/LogViewer-test.jsx.snap
+++ b/lib/windows/app/components/__tests__/__snapshots__/LogViewer-test.jsx.snap
@@ -18,7 +18,7 @@ exports[`LogViewer should render log entries 1`] = `
       <div
         className="core-log-time"
       >
-        13:41:36.0200
+        13:41:36.020
       </div>
       <div
         className="core-log-message"
@@ -32,12 +32,32 @@ exports[`LogViewer should render log entries 1`] = `
       <div
         className="core-log-time"
       >
-        14:41:36.0200
+        14:41:36.020
       </div>
       <div
         className="core-log-message"
       >
         Error message
+      </div>
+    </div>
+    <div
+      className="core-log-entry core-log-level-info"
+    >
+      <div
+        className="core-log-time"
+      >
+        14:41:36.020
+      </div>
+      <div
+        className="core-log-message"
+      >
+        For reference see: 
+        <a
+          href="https://github.com/example/doc.md"
+        >
+          https://github.com/example/doc.md
+        </a>
+         or reboot Windows.
       </div>
     </div>
   </Infinite>


### PR DESCRIPTION
Also fixed log entry timestamp representation to 3 digits to show milliseconds, since the underlying timestamp object only has that resolution.