### PR TITLE
Fix jest default transform and deprecated api calls

### DIFF
--- a/mocks/electronMock.js
+++ b/mocks/electronMock.js
@@ -5,9 +5,9 @@
 // Ref: https://facebook.github.io/jest/docs/tutorial-webpack.html
 
 module.exports = {
-    require: jest.genMockFunction(),
-    match: jest.genMockFunction(),
-    app: jest.genMockFunction(),
-    remote: jest.genMockFunction(),
-    dialog: jest.genMockFunction(),
+    require: jest.fn(),
+    match: jest.fn(),
+    app: jest.fn(),
+    remote: jest.fn(),
+    dialog: jest.fn(),
 };

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "electron-is-dev": "0.1.2",
         "moment": "2.18.1",
         "mousetrap": "1.6.1",
-        "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^1.2.2",
+        "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^1.3.0",
         "react-infinite": "github:NordicSemiconductor/react-infinite#react-15.5",
         "redux-logger": "3.0.1",
         "redux-thunk": "2.2.0",
@@ -133,6 +133,9 @@
             "\\.(css|less)$": "<rootDir>/mocks/styleMock.js",
             "electron": "<rootDir>/mocks/electronMock.js",
             "pc-nrfjprog-js": "<rootDir>/mocks/nrfjprogjsMock.js"
+        },
+        "transform": {
+            "^.+\\.jsx?$": "babel-jest"
         }
     }
 }


### PR DESCRIPTION
Looks like jest has never documented `genMockFunction()` which has finally been removed, so mock has been updated. Also default transform config doesn't transpile JSX files any more, that has been fixed too.