### PR TITLE
Fix jest snapshots and mocks

### DIFF
--- a/lib/windows/app/components/__tests__/__snapshots__/MainMenu-test.jsx.snap
+++ b/lib/windows/app/components/__tests__/__snapshots__/MainMenu-test.jsx.snap
@@ -63,7 +63,6 @@ exports[`MainMenu should render menu with two items separated by divider 1`] = `
       <li
         className=""
         role="presentation"
-        style={undefined}
       >
         <a
           href="#"
@@ -80,13 +79,10 @@ exports[`MainMenu should render menu with two items separated by divider 1`] = `
         className="divider"
         onKeyDown={[Function]}
         role="separator"
-        style={undefined}
-        title={undefined}
       />
       <li
         className=""
         role="presentation"
-        style={undefined}
       >
         <a
           href="#"

--- a/lib/windows/launcher/components/__tests__/__snapshots__/AppLaunchView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/AppLaunchView-test.jsx.snap
@@ -87,7 +87,6 @@ exports[`AppLaunchView should render app with no engine version 1`] = `
             <li
               className=""
               role="presentation"
-              style={undefined}
             >
               <a
                 href="#"
@@ -208,7 +207,6 @@ exports[`AppLaunchView should render app with unsupported engine version 1`] = `
             <li
               className=""
               role="presentation"
-              style={undefined}
             >
               <a
                 href="#"
@@ -329,7 +327,6 @@ exports[`AppLaunchView should render app with upgrade available 1`] = `
             <li
               className=""
               role="presentation"
-              style={undefined}
             >
               <a
                 href="#"
@@ -441,7 +438,6 @@ exports[`AppLaunchView should render apps sorted by name and isOfficial 1`] = `
             <li
               className=""
               role="presentation"
-              style={undefined}
             >
               <a
                 href="#"
@@ -546,7 +542,6 @@ exports[`AppLaunchView should render apps sorted by name and isOfficial 1`] = `
             <li
               className=""
               role="presentation"
-              style={undefined}
             >
               <a
                 href="#"
@@ -651,7 +646,6 @@ exports[`AppLaunchView should render apps sorted by name and isOfficial 1`] = `
             <li
               className=""
               role="presentation"
-              style={undefined}
             >
               <a
                 href="#"
@@ -756,7 +750,6 @@ exports[`AppLaunchView should render apps sorted by name and isOfficial 1`] = `
             <li
               className=""
               role="presentation"
-              style={undefined}
             >
               <a
                 href="#"
@@ -861,7 +854,6 @@ exports[`AppLaunchView should render apps sorted by name and isOfficial 1`] = `
             <li
               className=""
               role="presentation"
-              style={undefined}
             >
               <a
                 href="#"

--- a/mocks/emptyMock.js
+++ b/mocks/emptyMock.js
@@ -1,0 +1,3 @@
+// Allows jest to test files that import nrf-device-lister / nrf-device-setup.
+
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
         "webpack": "nrfconnect-scripts build-dev",
         "build": "nrfconnect-scripts build-prod",
         "lint": "nrfconnect-scripts lint main lib index.js",
-        "test": "nrfconnect-scripts test",
-        "test-watch": "nrfconnect-scripts test --watch",
+        "test": "jest --testResultsProcessor jest-bamboo-formatter",
+        "test-watch": "jest --watch",
         "test-e2e": "xvfb-maybe jest --runInBand --config test/setup/jest-e2e.json",
         "test-e2e-offline": "xvfb-maybe jest --runInBand --config test/setup/jest-e2e-offline.json",
         "test-e2e-online": "xvfb-maybe jest --runInBand --config test/setup/jest-e2e-online.json",
@@ -132,7 +132,9 @@
             "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$": "<rootDir>/mocks/fileMock.js",
             "\\.(css|less)$": "<rootDir>/mocks/styleMock.js",
             "electron": "<rootDir>/mocks/electronMock.js",
-            "pc-nrfjprog-js": "<rootDir>/mocks/nrfjprogjsMock.js"
+            "pc-nrfjprog-js": "<rootDir>/mocks/nrfjprogjsMock.js",
+            "nrf-device-lister": "<rootDir>/mocks/emptyMock.js",
+            "nrf-device-setup": "<rootDir>/mocks/emptyMock.js"
         },
         "transform": {
             "^.+\\.jsx?$": "babel-jest"


### PR DESCRIPTION
Unfortunately the common jest config doesn't cover the modules directly used by core and configs don't mix, so jest is now called directly from _npm_ rather than by wrapper scripts.
Snapshots are updated too.