### PR TITLE
Feature/upgrade to electron v2.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
-target = 1.8.7
-disturl = https://atom.io/download/atom-shell
+target = 2.0.6
+disturl = https://atom.io/download/electron

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "asar": "0.13.0",
         "babel-polyfill": "6.23.0",
         "bootstrap": "3.3.7",
-        "electron": "1.8.7",
+        "electron": "2.0.6",
         "electron-builder": "19.53.6",
         "electron-is-dev": "0.1.2",
         "moment": "2.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.5.0-alpha.1",
+    "version": "2.5.0-alpha.2",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR was created to keep the electron engine up to date with latest stable version 2.0.6.
Fortunately we didn't use any of the braking APIs, so the update is quite straightforward.
Auto-update and some smoke tests has been checked on all platform.
