### PR TITLE
Feature multiple sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,9 @@ electronApp.on('ready', () => {
     apps.initAppsDirectory()
         .then(() => {
             if (config.getOfficialAppName()) {
-                return windows.openOfficialAppWindow(config.getOfficialAppName());
+                return windows.openOfficialAppWindow(
+                    config.getOfficialAppName(), config.getSourceName(),
+                );
             } else if (config.getLocalAppName()) {
                 return windows.openLocalAppWindow(config.getLocalAppName());
             }

--- a/lib/windows/launcher/actions/appsActions.js
+++ b/lib/windows/launcher/actions/appsActions.js
@@ -99,17 +99,19 @@ function loadOfficialAppsError() {
     };
 }
 
-function installOfficialAppAction(name) {
+function installOfficialAppAction(name, source) {
     return {
         type: INSTALL_OFFICIAL_APP,
         name,
+        source,
     };
 }
 
-function installOfficialAppSuccessAction(name) {
+function installOfficialAppSuccessAction(name, source) {
     return {
         type: INSTALL_OFFICIAL_APP_SUCCESS,
         name,
+        source,
     };
 }
 
@@ -119,17 +121,19 @@ function installOfficialAppErrorAction() {
     };
 }
 
-function removeOfficialAppAction(name) {
+function removeOfficialAppAction(name, source) {
     return {
         type: REMOVE_OFFICIAL_APP,
         name,
+        source,
     };
 }
 
-function removeOfficialAppSuccessAction(name) {
+function removeOfficialAppSuccessAction(name, source) {
     return {
         type: REMOVE_OFFICIAL_APP_SUCCESS,
         name,
+        source,
     };
 }
 
@@ -139,19 +143,21 @@ function removeOfficialAppErrorAction() {
     };
 }
 
-function upgradeOfficialAppAction(name, version) {
+function upgradeOfficialAppAction(name, version, source) {
     return {
         type: UPGRADE_OFFICIAL_APP,
         name,
         version,
+        source,
     };
 }
 
-function upgradeOfficialAppSuccessAction(name, version) {
+function upgradeOfficialAppSuccessAction(name, version, source) {
     return {
         type: UPGRADE_OFFICIAL_APP_SUCCESS,
         name,
         version,
+        source,
     };
 }
 
@@ -197,8 +203,8 @@ export function downloadLatestAppInfo(options = { rejectIfError: false }) {
     return dispatch => {
         dispatch(downloadLatestAppInfoAction());
 
-        return mainApps.downloadAppsJsonFile()
-            .then(() => mainApps.generateUpdatesJsonFile())
+        return mainApps.downloadAppsJsonFiles()
+            .then(() => mainApps.generateUpdatesJsonFiles())
             .then(() => dispatch(downloadLatestAppInfoSuccessAction()))
             .catch(error => {
                 dispatch(downloadLatestAppInfoErrorAction());
@@ -237,12 +243,12 @@ export function loadOfficialApps() {
     };
 }
 
-export function installOfficialApp(name) {
+export function installOfficialApp(name, source, registryUrl) {
     return dispatch => {
-        dispatch(installOfficialAppAction(name));
-        mainApps.installOfficialApp(name, 'latest')
+        dispatch(installOfficialAppAction(name, source));
+        mainApps.installOfficialApp(name, 'latest', source, registryUrl)
             .then(() => {
-                dispatch(installOfficialAppSuccessAction(name));
+                dispatch(installOfficialAppSuccessAction(name, source));
                 dispatch(loadOfficialApps());
             })
             .catch(error => {
@@ -252,12 +258,12 @@ export function installOfficialApp(name) {
     };
 }
 
-export function removeOfficialApp(name) {
+export function removeOfficialApp(name, source) {
     return dispatch => {
-        dispatch(removeOfficialAppAction(name));
-        mainApps.removeOfficialApp(name)
+        dispatch(removeOfficialAppAction(name, source));
+        mainApps.removeOfficialApp(name, source)
             .then(() => {
-                dispatch(removeOfficialAppSuccessAction(name));
+                dispatch(removeOfficialAppSuccessAction(name, source));
                 dispatch(loadOfficialApps());
             })
             .catch(error => {
@@ -267,12 +273,12 @@ export function removeOfficialApp(name) {
     };
 }
 
-export function upgradeOfficialApp(name, version) {
+export function upgradeOfficialApp(name, version, source, registryUrl) {
     return dispatch => {
-        dispatch(upgradeOfficialAppAction(name, version));
-        return mainApps.installOfficialApp(name, version)
+        dispatch(upgradeOfficialAppAction(name, version, source));
+        return mainApps.installOfficialApp(name, version, source, registryUrl)
             .then(() => {
-                dispatch(upgradeOfficialAppSuccessAction(name, version));
+                dispatch(upgradeOfficialAppSuccessAction(name, version, source));
                 dispatch(loadOfficialApps());
             })
             .catch(error => {

--- a/lib/windows/launcher/actions/desktopShortcutActions.js
+++ b/lib/windows/launcher/actions/desktopShortcutActions.js
@@ -70,7 +70,7 @@ function getFileName(app) {
     const appName = `${app.displayName || app.name}`;
     let sourceName = ' (Local)';
     if (app.isOfficial) {
-        sourceName = (app.source === 'official') ? '' : ` ${app.source}`;
+        sourceName = (app.source === 'official') ? '' : ` (${app.source})`;
     }
     return `${appName}${sourceName}`;
 }

--- a/lib/windows/launcher/actions/desktopShortcutActions.js
+++ b/lib/windows/launcher/actions/desktopShortcutActions.js
@@ -67,7 +67,12 @@ const mode = (
  * @returns {String} file name from app.
  */
 function getFileName(app) {
-    return `${app.displayName || app.name}${app.isOfficial ? '' : ' (Local)'}`;
+    const appName = `${app.displayName || app.name}`;
+    let sourceName = ' (Local)';
+    if (app.isOfficial) {
+        sourceName = (app.source === 'official') ? '' : ` ${app.source}`;
+    }
+    return `${appName}${sourceName}`;
 }
 
 /**
@@ -77,7 +82,13 @@ function getFileName(app) {
  * @returns {String} arguments from app.
  */
 function getArgs(app) {
-    return `--args ${app.isOfficial ? '--open-official-app' : '--open-local-app'} ${app.name}`;
+    const args = ['--args'];
+    if (app.isOfficial) {
+        args.push('--open-official-app', app.name, '--source', app.source);
+    } else {
+        args.push('--open-local-app', app.name);
+    }
+    return args.join(' ');
 }
 
 /**

--- a/lib/windows/launcher/actions/settingsActions.js
+++ b/lib/windows/launcher/actions/settingsActions.js
@@ -40,6 +40,7 @@ import * as AppsActions from './appsActions';
 import * as AutoUpdateActions from './autoUpdateActions';
 
 const settings = remote.require('./main/settings');
+const mainApps = remote.require('./main/apps');
 
 export const SETTINGS_LOAD = 'SETTINGS_LOAD';
 export const SETTINGS_LOAD_SUCCESS = 'SETTINGS_LOAD_SUCCESS';
@@ -47,6 +48,12 @@ export const SETTINGS_LOAD_ERROR = 'SETTINGS_LOAD_ERROR';
 export const SETTINGS_CHECK_UPDATES_AT_STARTUP_CHANGED = 'SETTINGS_CHECK_UPDATES_AT_STARTUP_CHANGED';
 export const SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_SHOW = 'SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_SHOW';
 export const SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE = 'SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE';
+export const SETTINGS_SOURCE_ADDED = 'SETTINGS_SOURCE_ADDED';
+export const SETTINGS_SOURCE_REMOVED = 'SETTINGS_SOURCE_REMOVED';
+export const SETTINGS_ADD_SOURCE_DIALOG_SHOW = 'SETTINGS_ADD_SOURCE_DIALOG_SHOW';
+export const SETTINGS_ADD_SOURCE_DIALOG_HIDE = 'SETTINGS_ADD_SOURCE_DIALOG_HIDE';
+export const SETTINGS_REMOVE_SOURCE_DIALOG_SHOW = 'SETTINGS_REMOVE_SOURCE_DIALOG_SHOW';
+export const SETTINGS_REMOVE_SOURCE_DIALOG_HIDE = 'SETTINGS_REMOVE_SOURCE_DIALOG_HIDE';
 
 function loadSettingsAction() {
     return {
@@ -83,8 +90,10 @@ export function loadSettings() {
             if (shouldCheckForUpdatesAtStartup === null) {
                 shouldCheckForUpdatesAtStartup = true;
             }
+            const sources = settings.getSources();
             dispatch(loadSettingsSuccessAction({
                 shouldCheckForUpdatesAtStartup,
+                sources,
             }));
         } catch (error) {
             dispatch(loadSettingsErrorAction(error));
@@ -127,4 +136,75 @@ export function checkForUpdatesButtonClicked() {
                 dispatch(ErrorDialogActions.showDialog(`Unable to check for updates: ${error.message}`))
             ))
     );
+}
+
+function addSourceAction(name, url) {
+    return {
+        type: SETTINGS_SOURCE_ADDED,
+        name,
+        url,
+    };
+}
+
+export function addSource(url) {
+    return (dispatch, getState) => {
+        mainApps.downloadAppsJsonFile(url)
+            .then(source => dispatch(addSourceAction(source, url)))
+            .then(() => {
+                try {
+                    settings.setSources(getState().settings.sources.toJS());
+                } catch (error) {
+                    dispatch(ErrorDialogActions.showDialog(`Unable to save settings: ${error.message}`));
+                }
+            })
+            .catch(error => dispatch(ErrorDialogActions.showDialog(error.message)))
+            .then(() => dispatch(AppsActions.loadOfficialApps()));
+    };
+}
+
+function sourceRemovedAction(name) {
+    return {
+        type: SETTINGS_SOURCE_REMOVED,
+        name,
+    };
+}
+
+export function removeSource(name) {
+    return (dispatch, getState) => {
+        mainApps.removeSourceDirectory(name)
+            .then(() => dispatch(sourceRemovedAction(name)))
+            .then(() => {
+                try {
+                    settings.setSources(getState().settings.sources.toJS());
+                } catch (error) {
+                    dispatch(ErrorDialogActions.showDialog(`Unable to save settings: ${error.message}`));
+                }
+            })
+            .then(() => dispatch(AppsActions.loadOfficialApps()));
+    };
+}
+
+export function showAddSourceDialog() {
+    return {
+        type: SETTINGS_ADD_SOURCE_DIALOG_SHOW,
+    };
+}
+
+export function hideAddSourceDialog() {
+    return {
+        type: SETTINGS_ADD_SOURCE_DIALOG_HIDE,
+    };
+}
+
+export function showRemoveSourceDialog(name) {
+    return {
+        type: SETTINGS_REMOVE_SOURCE_DIALOG_SHOW,
+        name,
+    };
+}
+
+export function hideRemoveSourceDialog() {
+    return {
+        type: SETTINGS_REMOVE_SOURCE_DIALOG_HIDE,
+    };
 }

--- a/lib/windows/launcher/components/AppManagementView.jsx
+++ b/lib/windows/launcher/components/AppManagementView.jsx
@@ -95,21 +95,23 @@ class AppManagementView extends React.Component {
                     getSortedApps(apps).map(app => (
                         app.currentVersion ?
                             <InstalledAppItem
-                                key={app.name}
+                                key={`${app.name}-${app.source}`}
                                 app={app}
                                 isDisabled={isProcessing}
                                 isUpgrading={upgradingAppName === app.name}
                                 isRemoving={removingAppName === app.name}
-                                onRemove={() => onRemove(app.name)}
-                                onUpgrade={() => onUpgrade(app.name, app.latestVersion)}
+                                onRemove={() => onRemove(app.name, app.source)}
+                                onUpgrade={() => onUpgrade(
+                                    app.name, app.latestVersion, app.source, app.url,
+                                )}
                                 onReadMore={() => onReadMore(app.homepage)}
                             /> :
                             <AvailableAppItem
-                                key={app.name}
+                                key={`${app.name}-${app.source}`}
                                 app={app}
                                 isDisabled={isProcessing}
                                 isInstalling={installingAppName === app.name}
-                                onInstall={() => onInstall(app.name)}
+                                onInstall={() => onInstall(app.name, app.source, app.url)}
                                 onReadMore={() => onReadMore(app.homepage)}
                             />
                     ))

--- a/lib/windows/launcher/components/AvailableAppItem.jsx
+++ b/lib/windows/launcher/components/AvailableAppItem.jsx
@@ -47,7 +47,7 @@ const AvailableAppItem = ({
 }) => (
     <div className="core-app-management-item list-group-item">
         <h4 className="list-group-item-heading">{app.displayName || app.name}
-            <span className="list-group-item-heading-sourcetag">{app.source}</span>
+            <span className="list-group-item-heading-source-tag">{app.source}</span>
         </h4>
         <div className="list-group-item-text">
             <p>{app.description}</p>

--- a/lib/windows/launcher/components/ConfirmRemoveSourceDialog.jsx
+++ b/lib/windows/launcher/components/ConfirmRemoveSourceDialog.jsx
@@ -58,9 +58,13 @@ const ConfirmRemoveSourceDialog = ({
 
 ConfirmRemoveSourceDialog.propTypes = {
     isVisible: PropTypes.bool.isRequired,
-    source: PropTypes.string.isRequired,
+    source: PropTypes.string,
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+};
+
+ConfirmRemoveSourceDialog.defaultProps = {
+    source: null,
 };
 
 export default ConfirmRemoveSourceDialog;

--- a/lib/windows/launcher/components/ConfirmRemoveSourceDialog.jsx
+++ b/lib/windows/launcher/components/ConfirmRemoveSourceDialog.jsx
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2015 - 2018, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -36,55 +36,31 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import AppItemButton from './AppItemButton';
 
-const AvailableAppItem = ({
-    app,
-    onInstall,
-    onReadMore,
-    isInstalling,
-    isDisabled,
+import ConfirmationDialog from '../../../components/ConfirmationDialog';
+
+const ConfirmRemoveSourceDialog = ({
+    isVisible,
+    source,
+    onConfirm,
+    onCancel,
 }) => (
-    <div className="core-app-management-item list-group-item">
-        <h4 className="list-group-item-heading">{app.displayName || app.name}
-            <span className="list-group-item-heading-sourcetag">{app.source}</span>
-        </h4>
-        <div className="list-group-item-text">
-            <p>{app.description}</p>
-            <div className="core-app-management-item-footer">
-                <button className="btn btn-link core-btn-link" onClick={onReadMore}>
-                    More information
-                </button>
-                <div className="core-app-management-item-buttons">
-                    <AppItemButton
-                        text={isInstalling ? 'Installing...' : 'Install'}
-                        title={`Install ${app.displayName || app.name}`}
-                        iconClass="glyphicon glyphicon-download-alt"
-                        isDisabled={isDisabled}
-                        onClick={onInstall}
-                    />
-                </div>
-            </div>
-        </div>
-    </div>
+    <ConfirmationDialog
+        isVisible={isVisible}
+        title="Remove app source"
+        text={`Are you sure to remove "${source}" source along with any apps installed from it?`}
+        okButtonText="Yes, remove"
+        cancelButtonText="Cancel"
+        onOk={() => onConfirm(source)}
+        onCancel={onCancel}
+    />
 );
 
-AvailableAppItem.propTypes = {
-    app: PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        displayName: PropTypes.string,
-        description: PropTypes.string.isRequired,
-        homepage: PropTypes.string,
-    }).isRequired,
-    isInstalling: PropTypes.bool,
-    isDisabled: PropTypes.bool,
-    onInstall: PropTypes.func.isRequired,
-    onReadMore: PropTypes.func.isRequired,
+ConfirmRemoveSourceDialog.propTypes = {
+    isVisible: PropTypes.bool.isRequired,
+    source: PropTypes.string.isRequired,
+    onConfirm: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
 };
 
-AvailableAppItem.defaultProps = {
-    isInstalling: false,
-    isDisabled: false,
-};
-
-export default AvailableAppItem;
+export default ConfirmRemoveSourceDialog;

--- a/lib/windows/launcher/components/InputLineDialog.jsx
+++ b/lib/windows/launcher/components/InputLineDialog.jsx
@@ -1,0 +1,106 @@
+/* Copyright (c) 2015 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+    Button, ControlLabel, FormControl, FormGroup,
+    Modal, ModalHeader, ModalBody, ModalFooter, ModalTitle,
+} from 'react-bootstrap';
+
+class InputLineDialog extends React.Component {
+    render() {
+        const {
+            isVisible,
+            title,
+            label,
+            placeholder,
+            onOk,
+            onCancel,
+        } = this.props;
+        return (
+            <Modal show={isVisible} onHide={onCancel} backdrop={'static'}>
+                <ModalHeader>
+                    <ModalTitle>{title}</ModalTitle>
+                </ModalHeader>
+                <form onSubmit={() => onOk(this.inputNode.value)}>
+                    <ModalBody>
+                        <FormGroup>
+                            <ControlLabel>{label}</ControlLabel>
+                            <FormControl
+                                type="text"
+                                inputRef={ref => { this.inputNode = ref; }}
+                                placeholder={placeholder}
+                            />
+                        </FormGroup>
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button
+                            type="submit"
+                            bsStyle="primary"
+                            className="core-btn"
+                            onClick={() => onOk(this.inputNode.value)}
+                        >
+                            OK
+                        </Button>
+                        <Button
+                            className="core-btn"
+                            onClick={() => onCancel()}
+                        >
+                            Cancel
+                        </Button>
+                    </ModalFooter>
+                </form>
+            </Modal>
+        );
+    }
+}
+
+InputLineDialog.propTypes = {
+    isVisible: PropTypes.bool,
+    title: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    placeholder: PropTypes.string,
+    onOk: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+};
+
+InputLineDialog.defaultProps = {
+    isVisible: false,
+    placeholder: null,
+};
+
+export default InputLineDialog;

--- a/lib/windows/launcher/components/InstalledAppItem.jsx
+++ b/lib/windows/launcher/components/InstalledAppItem.jsx
@@ -52,7 +52,9 @@ const InstalledAppItem = ({
     const statusText = isUpgradeAvailable ? 'Upgrade available' : 'Installed';
     return (
         <div className="core-app-management-item list-group-item">
-            <h4 className="list-group-item-heading">{app.displayName || app.name}</h4>
+            <h4 className="list-group-item-heading">{app.displayName || app.name}
+                <span className="list-group-item-heading-sourcetag">{app.source}</span>
+            </h4>
             <div className="list-group-item-text">
                 <p>{app.description}</p>
                 <div className="core-app-management-item-footer">

--- a/lib/windows/launcher/components/InstalledAppItem.jsx
+++ b/lib/windows/launcher/components/InstalledAppItem.jsx
@@ -53,7 +53,7 @@ const InstalledAppItem = ({
     return (
         <div className="core-app-management-item list-group-item">
             <h4 className="list-group-item-heading">{app.displayName || app.name}
-                <span className="list-group-item-heading-sourcetag">{app.source}</span>
+                <span className="list-group-item-heading-source-tag">{app.source}</span>
             </h4>
             <div className="list-group-item-text">
                 <p>{app.description}</p>

--- a/lib/windows/launcher/components/LaunchableAppItem.jsx
+++ b/lib/windows/launcher/components/LaunchableAppItem.jsx
@@ -48,7 +48,7 @@ const LaunchableAppItem = ({ app, onClick, onCreateShortcut }) => (
         <div>
             <h4 className="list-group-item-heading">{app.displayName || app.name}</h4>
             <p className="list-group-item-text">
-                {app.isOfficial ? 'official' : 'local'}, v{app.currentVersion}
+                {app.isOfficial ? app.source : 'local'}, v{app.currentVersion}
             </p>
         </div>
         <div className="core-app-launch-item-buttons btn-toolbar">
@@ -79,6 +79,7 @@ LaunchableAppItem.propTypes = {
         isOfficial: PropTypes.bool.isRequired,
         engineVersion: PropTypes.string,
         isSupportedEngine: PropTypes.bool,
+        source: PropTypes.string,
     }).isRequired,
     onClick: PropTypes.func.isRequired,
     onCreateShortcut: PropTypes.func.isRequired,

--- a/lib/windows/launcher/components/__tests__/AppManagementView-test.jsx
+++ b/lib/windows/launcher/components/__tests__/AppManagementView-test.jsx
@@ -191,10 +191,12 @@ describe('AppManagementView', () => {
         )).toMatchSnapshot();
     });
 
-    it('should invoke onInstall with app name when install button is clicked', () => {
+    it('should invoke onInstall with app name, source and url when install button is clicked', () => {
         const app = getImmutableApp({
             name: 'pc-nrfconnect-foobar',
             description: 'Foobar description',
+            source: 'beta',
+            url: 'https://foo.bar/dists/beta',
         });
         const onInstall = jest.fn();
         const wrapper = mount(
@@ -211,15 +213,16 @@ describe('AppManagementView', () => {
         );
         wrapper.find('button[title="Install pc-nrfconnect-foobar"]').first().simulate('click');
 
-        expect(onInstall).toHaveBeenCalledWith(app.name);
+        expect(onInstall).toHaveBeenCalledWith(app.name, app.source, app.url);
     });
 
-    it('should invoke onRemove with app name when remove button is clicked', () => {
+    it('should invoke onRemove with app name and source when remove button is clicked', () => {
         const app = getImmutableApp({
             name: 'pc-nrfconnect-foobar',
             description: 'Foobar description',
             currentVersion: '1.2.3',
             latestVersion: '1.2.3',
+            source: 'beta',
         });
         const onRemove = jest.fn();
         const wrapper = mount(
@@ -236,7 +239,7 @@ describe('AppManagementView', () => {
         );
         wrapper.find('button[title="Remove pc-nrfconnect-foobar"]').first().simulate('click');
 
-        expect(onRemove).toHaveBeenCalledWith(app.name);
+        expect(onRemove).toHaveBeenCalledWith(app.name, app.source);
     });
 
     it('should invoke onUpgrade with app name and latest version when upgrade button is clicked', () => {
@@ -245,6 +248,8 @@ describe('AppManagementView', () => {
             description: 'Foobar description',
             currentVersion: '1.2.3',
             latestVersion: '1.2.4',
+            source: 'beta',
+            url: 'https://foo.bar/dists/beta',
         });
         const onUpgrade = jest.fn();
         const wrapper = mount(
@@ -261,7 +266,7 @@ describe('AppManagementView', () => {
         );
         wrapper.find('button[title="Upgrade pc-nrfconnect-foobar from v1.2.3 to v1.2.4"]').first().simulate('click');
 
-        expect(onUpgrade).toHaveBeenCalledWith(app.name, app.latestVersion);
+        expect(onUpgrade).toHaveBeenCalledWith(app.name, app.latestVersion, app.source, app.url);
     });
 
     it('should invoke onDownloadLatestAppInfo when mounted and latest app info is not downloaded', () => {

--- a/lib/windows/launcher/components/__tests__/SettingsView-test.jsx
+++ b/lib/windows/launcher/components/__tests__/SettingsView-test.jsx
@@ -47,8 +47,11 @@ jest.mock('react-bootstrap', () => ({
     Checkbox: 'Checkbox',
 }));
 
+jest.mock('../../containers/ConfirmRemoveSourceDialog', () => 'ConfirmRemoveSourceDialog');
+
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { Map } from 'immutable';
 import SettingsView from '../SettingsView';
 
 describe('SettingsView', () => {
@@ -61,6 +64,11 @@ describe('SettingsView', () => {
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
                 onHideUpdateCheckCompleteDialog={() => {}}
+                sources={Map({})}
+                addSource={() => {}}
+                onShowRemoveSourceDialog={() => {}}
+                onShowAddSourceDialog={() => {}}
+                onHideAddSourceDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -74,6 +82,11 @@ describe('SettingsView', () => {
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
                 onHideUpdateCheckCompleteDialog={() => {}}
+                sources={Map({})}
+                addSource={() => {}}
+                onShowRemoveSourceDialog={() => {}}
+                onShowAddSourceDialog={() => {}}
+                onHideAddSourceDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -87,6 +100,11 @@ describe('SettingsView', () => {
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
                 onHideUpdateCheckCompleteDialog={() => {}}
+                sources={Map({})}
+                addSource={() => {}}
+                onShowRemoveSourceDialog={() => {}}
+                onShowAddSourceDialog={() => {}}
+                onHideAddSourceDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -100,6 +118,11 @@ describe('SettingsView', () => {
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
                 onHideUpdateCheckCompleteDialog={() => {}}
+                sources={Map({})}
+                addSource={() => {}}
+                onShowRemoveSourceDialog={() => {}}
+                onShowAddSourceDialog={() => {}}
+                onHideAddSourceDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -114,6 +137,11 @@ describe('SettingsView', () => {
                 onTriggerUpdateCheck={() => {}}
                 onCheckUpdatesAtStartupChanged={() => {}}
                 onHideUpdateCheckCompleteDialog={() => {}}
+                sources={Map({})}
+                addSource={() => {}}
+                onShowRemoveSourceDialog={() => {}}
+                onShowAddSourceDialog={() => {}}
+                onHideAddSourceDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -130,6 +158,11 @@ describe('SettingsView', () => {
                 onHideUpdateCheckCompleteDialog={() => {}}
                 isUpdateCheckCompleteDialogVisible
                 isAppUpdateAvailable
+                sources={Map({})}
+                addSource={() => {}}
+                onShowRemoveSourceDialog={() => {}}
+                onShowAddSourceDialog={() => {}}
+                onHideAddSourceDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -146,6 +179,11 @@ describe('SettingsView', () => {
                 onHideUpdateCheckCompleteDialog={() => {}}
                 isUpdateCheckCompleteDialogVisible
                 isAppUpdateAvailable={false}
+                sources={Map({})}
+                addSource={() => {}}
+                onShowRemoveSourceDialog={() => {}}
+                onShowAddSourceDialog={() => {}}
+                onHideAddSourceDialog={() => {}}
             />,
         )).toMatchSnapshot();
     });

--- a/lib/windows/launcher/components/__tests__/__snapshots__/AppLaunchView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/AppLaunchView-test.jsx.snap
@@ -274,7 +274,6 @@ exports[`AppLaunchView should render app with upgrade available 1`] = `
       <p
         className="list-group-item-text"
       >
-        official
         , v
         1.2.3
       </p>
@@ -385,7 +384,6 @@ exports[`AppLaunchView should render apps sorted by name and isOfficial 1`] = `
       <p
         className="list-group-item-text"
       >
-        official
         , v
         1.2.3
       </p>
@@ -489,7 +487,6 @@ exports[`AppLaunchView should render apps sorted by name and isOfficial 1`] = `
       <p
         className="list-group-item-text"
       >
-        official
         , v
         1.2.3
       </p>
@@ -697,7 +694,6 @@ exports[`AppLaunchView should render apps sorted by name and isOfficial 1`] = `
       <p
         className="list-group-item-text"
       >
-        official
         , v
         1.2.3
       </p>

--- a/lib/windows/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
@@ -10,7 +10,7 @@ exports[`AppManagementView should disable buttons and display "Installing..." bu
     >
       Foo app
       <span
-        className="list-group-item-heading-sourcetag"
+        className="list-group-item-heading-source-tag"
       />
     </h4>
     <div
@@ -63,7 +63,7 @@ exports[`AppManagementView should disable buttons and display "Removing..." butt
     >
       Foo app
       <span
-        className="list-group-item-heading-sourcetag"
+        className="list-group-item-heading-source-tag"
       />
     </h4>
     <div
@@ -122,7 +122,7 @@ exports[`AppManagementView should disable buttons and display "Upgrading..." but
     >
       Foo app
       <span
-        className="list-group-item-heading-sourcetag"
+        className="list-group-item-heading-source-tag"
       />
     </h4>
     <div
@@ -195,7 +195,7 @@ exports[`AppManagementView should render not-installed, installed, and upgradabl
     >
       App A
       <span
-        className="list-group-item-heading-sourcetag"
+        className="list-group-item-heading-source-tag"
       />
     </h4>
     <div
@@ -263,7 +263,7 @@ exports[`AppManagementView should render not-installed, installed, and upgradabl
     >
       App B
       <span
-        className="list-group-item-heading-sourcetag"
+        className="list-group-item-heading-source-tag"
       />
     </h4>
     <div
@@ -311,7 +311,7 @@ exports[`AppManagementView should render not-installed, installed, and upgradabl
     >
       App C
       <span
-        className="list-group-item-heading-sourcetag"
+        className="list-group-item-heading-source-tag"
       />
     </h4>
     <div

--- a/lib/windows/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
@@ -9,6 +9,9 @@ exports[`AppManagementView should disable buttons and display "Installing..." bu
       className="list-group-item-heading"
     >
       Foo app
+      <span
+        className="list-group-item-heading-sourcetag"
+      />
     </h4>
     <div
       className="list-group-item-text"
@@ -59,6 +62,9 @@ exports[`AppManagementView should disable buttons and display "Removing..." butt
       className="list-group-item-heading"
     >
       Foo app
+      <span
+        className="list-group-item-heading-sourcetag"
+      />
     </h4>
     <div
       className="list-group-item-text"
@@ -115,6 +121,9 @@ exports[`AppManagementView should disable buttons and display "Upgrading..." but
       className="list-group-item-heading"
     >
       Foo app
+      <span
+        className="list-group-item-heading-sourcetag"
+      />
     </h4>
     <div
       className="list-group-item-text"
@@ -185,6 +194,9 @@ exports[`AppManagementView should render not-installed, installed, and upgradabl
       className="list-group-item-heading"
     >
       App A
+      <span
+        className="list-group-item-heading-sourcetag"
+      />
     </h4>
     <div
       className="list-group-item-text"
@@ -250,6 +262,9 @@ exports[`AppManagementView should render not-installed, installed, and upgradabl
       className="list-group-item-heading"
     >
       App B
+      <span
+        className="list-group-item-heading-sourcetag"
+      />
     </h4>
     <div
       className="list-group-item-text"
@@ -295,6 +310,9 @@ exports[`AppManagementView should render not-installed, installed, and upgradabl
       className="list-group-item-heading"
     >
       App C
+      <span
+        className="list-group-item-heading-sourcetag"
+      />
     </h4>
     <div
       className="list-group-item-text"

--- a/lib/windows/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
@@ -21,7 +21,7 @@ exports[`SettingsView should render check for updates completed, with everything
       >
         Check for updates at startup
       </Checkbox>
-      <button
+      <Button
         className="btn btn-primary core-btn"
         disabled={false}
         onClick={[Function]}
@@ -35,7 +35,7 @@ exports[`SettingsView should render check for updates completed, with everything
         >
           Check for updates now
         </span>
-      </button>
+      </Button>
     </div>
   </div>
   <Modal
@@ -67,6 +67,39 @@ exports[`SettingsView should render check for updates completed, with everything
       </Button>
     </ModalFooter>
   </Modal>
+  <div
+    className="core-settings-section"
+    onDragEnter={[Function]}
+    onDragOver={[Function]}
+    onDrop={[Function]}
+  >
+    <h4>
+      Extra app sources
+    </h4>
+    <table
+      className="core-settings-sources"
+    >
+      <tbody />
+    </table>
+    <div
+      className="core-settings-sources-controls"
+    >
+      <Button
+        className="btn btn-primary core-btn"
+        onClick={[Function]}
+      >
+        <span
+          className="glyphicon glyphicon-plus"
+        />
+        <span
+          className="core-btn-text"
+        >
+          Add source
+        </span>
+      </Button>
+    </div>
+  </div>
+  <ConfirmRemoveSourceDialog />
 </div>
 `;
 
@@ -91,7 +124,7 @@ exports[`SettingsView should render check for updates completed, with updates av
       >
         Check for updates at startup
       </Checkbox>
-      <button
+      <Button
         className="btn btn-primary core-btn"
         disabled={false}
         onClick={[Function]}
@@ -105,7 +138,7 @@ exports[`SettingsView should render check for updates completed, with updates av
         >
           Check for updates now
         </span>
-      </button>
+      </Button>
     </div>
   </div>
   <Modal
@@ -137,6 +170,39 @@ exports[`SettingsView should render check for updates completed, with updates av
       </Button>
     </ModalFooter>
   </Modal>
+  <div
+    className="core-settings-section"
+    onDragEnter={[Function]}
+    onDragOver={[Function]}
+    onDrop={[Function]}
+  >
+    <h4>
+      Extra app sources
+    </h4>
+    <table
+      className="core-settings-sources"
+    >
+      <tbody />
+    </table>
+    <div
+      className="core-settings-sources-controls"
+    >
+      <Button
+        className="btn btn-primary core-btn"
+        onClick={[Function]}
+      >
+        <span
+          className="glyphicon glyphicon-plus"
+        />
+        <span
+          className="core-btn-text"
+        >
+          Add source
+        </span>
+      </Button>
+    </div>
+  </div>
+  <ConfirmRemoveSourceDialog />
 </div>
 `;
 
@@ -159,7 +225,7 @@ exports[`SettingsView should render when checking for updates 1`] = `
       >
         Check for updates at startup
       </Checkbox>
-      <button
+      <Button
         className="btn btn-primary core-btn"
         disabled={true}
         onClick={[Function]}
@@ -173,9 +239,42 @@ exports[`SettingsView should render when checking for updates 1`] = `
         >
           Checking...
         </span>
-      </button>
+      </Button>
     </div>
   </div>
+  <div
+    className="core-settings-section"
+    onDragEnter={[Function]}
+    onDragOver={[Function]}
+    onDrop={[Function]}
+  >
+    <h4>
+      Extra app sources
+    </h4>
+    <table
+      className="core-settings-sources"
+    >
+      <tbody />
+    </table>
+    <div
+      className="core-settings-sources-controls"
+    >
+      <Button
+        className="btn btn-primary core-btn"
+        onClick={[Function]}
+      >
+        <span
+          className="glyphicon glyphicon-plus"
+        />
+        <span
+          className="core-btn-text"
+        >
+          Add source
+        </span>
+      </Button>
+    </div>
+  </div>
+  <ConfirmRemoveSourceDialog />
 </div>
 `;
 
@@ -196,7 +295,7 @@ exports[`SettingsView should render with check for updates disabled 1`] = `
       >
         Check for updates at startup
       </Checkbox>
-      <button
+      <Button
         className="btn btn-primary core-btn"
         disabled={false}
         onClick={[Function]}
@@ -210,9 +309,42 @@ exports[`SettingsView should render with check for updates disabled 1`] = `
         >
           Check for updates now
         </span>
-      </button>
+      </Button>
     </div>
   </div>
+  <div
+    className="core-settings-section"
+    onDragEnter={[Function]}
+    onDragOver={[Function]}
+    onDrop={[Function]}
+  >
+    <h4>
+      Extra app sources
+    </h4>
+    <table
+      className="core-settings-sources"
+    >
+      <tbody />
+    </table>
+    <div
+      className="core-settings-sources-controls"
+    >
+      <Button
+        className="btn btn-primary core-btn"
+        onClick={[Function]}
+      >
+        <span
+          className="glyphicon glyphicon-plus"
+        />
+        <span
+          className="core-btn-text"
+        >
+          Add source
+        </span>
+      </Button>
+    </div>
+  </div>
+  <ConfirmRemoveSourceDialog />
 </div>
 `;
 
@@ -233,7 +365,7 @@ exports[`SettingsView should render with check for updates enabled 1`] = `
       >
         Check for updates at startup
       </Checkbox>
-      <button
+      <Button
         className="btn btn-primary core-btn"
         disabled={false}
         onClick={[Function]}
@@ -247,9 +379,42 @@ exports[`SettingsView should render with check for updates enabled 1`] = `
         >
           Check for updates now
         </span>
-      </button>
+      </Button>
     </div>
   </div>
+  <div
+    className="core-settings-section"
+    onDragEnter={[Function]}
+    onDragOver={[Function]}
+    onDrop={[Function]}
+  >
+    <h4>
+      Extra app sources
+    </h4>
+    <table
+      className="core-settings-sources"
+    >
+      <tbody />
+    </table>
+    <div
+      className="core-settings-sources-controls"
+    >
+      <Button
+        className="btn btn-primary core-btn"
+        onClick={[Function]}
+      >
+        <span
+          className="glyphicon glyphicon-plus"
+        />
+        <span
+          className="core-btn-text"
+        >
+          Add source
+        </span>
+      </Button>
+    </div>
+  </div>
+  <ConfirmRemoveSourceDialog />
 </div>
 `;
 
@@ -274,7 +439,7 @@ exports[`SettingsView should render with last update check date 1`] = `
       >
         Check for updates at startup
       </Checkbox>
-      <button
+      <Button
         className="btn btn-primary core-btn"
         disabled={false}
         onClick={[Function]}
@@ -288,8 +453,41 @@ exports[`SettingsView should render with last update check date 1`] = `
         >
           Check for updates now
         </span>
-      </button>
+      </Button>
     </div>
   </div>
+  <div
+    className="core-settings-section"
+    onDragEnter={[Function]}
+    onDragOver={[Function]}
+    onDrop={[Function]}
+  >
+    <h4>
+      Extra app sources
+    </h4>
+    <table
+      className="core-settings-sources"
+    >
+      <tbody />
+    </table>
+    <div
+      className="core-settings-sources-controls"
+    >
+      <Button
+        className="btn btn-primary core-btn"
+        onClick={[Function]}
+      >
+        <span
+          className="glyphicon glyphicon-plus"
+        />
+        <span
+          className="core-btn-text"
+        >
+          Add source
+        </span>
+      </Button>
+    </div>
+  </div>
+  <ConfirmRemoveSourceDialog />
 </div>
 `;

--- a/lib/windows/launcher/containers/AppManagementContainer.js
+++ b/lib/windows/launcher/containers/AppManagementContainer.js
@@ -58,9 +58,13 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        onInstall: name => dispatch(AppsActions.installOfficialApp(name)),
-        onRemove: name => dispatch(AppsActions.removeOfficialApp(name)),
-        onUpgrade: (name, version) => dispatch(AppsActions.upgradeOfficialApp(name, version)),
+        onInstall: (name, source, url) => dispatch(
+            AppsActions.installOfficialApp(name, source, url),
+        ),
+        onRemove: (name, source) => dispatch(AppsActions.removeOfficialApp(name, source)),
+        onUpgrade: (name, version, source, url) => dispatch(
+            AppsActions.upgradeOfficialApp(name, version, source, url),
+        ),
         onReadMore: homepage => openUrlInDefaultBrowser(homepage),
         onDownloadLatestAppInfo: () => dispatch(AppsActions.downloadLatestAppInfo()),
     };

--- a/lib/windows/launcher/containers/ConfirmRemoveSourceDialog.js
+++ b/lib/windows/launcher/containers/ConfirmRemoveSourceDialog.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2015 - 2018, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/lib/windows/launcher/containers/ConfirmRemoveSourceDialog.js
+++ b/lib/windows/launcher/containers/ConfirmRemoveSourceDialog.js
@@ -34,57 +34,28 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import AppItemButton from './AppItemButton';
+import { connect } from 'react-redux';
+import ConfirmRemoveSourceDialog from '../components/ConfirmRemoveSourceDialog';
+import * as SettingsActions from '../actions/settingsActions';
 
-const AvailableAppItem = ({
-    app,
-    onInstall,
-    onReadMore,
-    isInstalling,
-    isDisabled,
-}) => (
-    <div className="core-app-management-item list-group-item">
-        <h4 className="list-group-item-heading">{app.displayName || app.name}
-            <span className="list-group-item-heading-sourcetag">{app.source}</span>
-        </h4>
-        <div className="list-group-item-text">
-            <p>{app.description}</p>
-            <div className="core-app-management-item-footer">
-                <button className="btn btn-link core-btn-link" onClick={onReadMore}>
-                    More information
-                </button>
-                <div className="core-app-management-item-buttons">
-                    <AppItemButton
-                        text={isInstalling ? 'Installing...' : 'Install'}
-                        title={`Install ${app.displayName || app.name}`}
-                        iconClass="glyphicon glyphicon-download-alt"
-                        isDisabled={isDisabled}
-                        onClick={onInstall}
-                    />
-                </div>
-            </div>
-        </div>
-    </div>
-);
+function mapStateToProps(state) {
+    return {
+        source: state.settings.removeSource,
+        isVisible: state.settings.isRemoveSourceDialogVisible,
+    };
+}
 
-AvailableAppItem.propTypes = {
-    app: PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        displayName: PropTypes.string,
-        description: PropTypes.string.isRequired,
-        homepage: PropTypes.string,
-    }).isRequired,
-    isInstalling: PropTypes.bool,
-    isDisabled: PropTypes.bool,
-    onInstall: PropTypes.func.isRequired,
-    onReadMore: PropTypes.func.isRequired,
-};
+function mapDispatchToProps(dispatch) {
+    return {
+        onConfirm: source => {
+            dispatch(SettingsActions.hideRemoveSourceDialog());
+            dispatch(SettingsActions.removeSource(source));
+        },
+        onCancel: () => dispatch(SettingsActions.hideRemoveSourceDialog()),
+    };
+}
 
-AvailableAppItem.defaultProps = {
-    isInstalling: false,
-    isDisabled: false,
-};
-
-export default AvailableAppItem;
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(ConfirmRemoveSourceDialog);

--- a/lib/windows/launcher/containers/SettingsContainer.js
+++ b/lib/windows/launcher/containers/SettingsContainer.js
@@ -52,6 +52,9 @@ function mapStateToProps(state) {
         isUpdateCheckCompleteDialogVisible: settings.isUpdateCheckCompleteDialogVisible,
         lastUpdateCheckDate: apps.lastUpdateCheckDate,
         isAppUpdateAvailable: isAppUpdateAvailable(apps.officialApps),
+        sources: settings.sources,
+        isAddSourceDialogVisible: settings.isAddSourceDialogVisible,
+        isRemoveSourceDialogVisible: settings.isRemoveSourceDialogVisible,
     };
 }
 
@@ -65,6 +68,20 @@ function mapDispatchToProps(dispatch) {
         ),
         onHideUpdateCheckCompleteDialog: () => (
             dispatch(SettingsActions.hideUpdateCheckCompleteDialog())
+        ),
+        addSource: url => dispatch(SettingsActions.addSource(url)),
+        removeSource: name => dispatch(SettingsActions.removeSource(name)),
+        onShowAddSourceDialog: () => (
+            dispatch(SettingsActions.showAddSourceDialog())
+        ),
+        onHideAddSourceDialog: () => (
+            dispatch(SettingsActions.hideAddSourceDialog())
+        ),
+        onShowRemoveSourceDialog: name => (
+            dispatch(SettingsActions.showRemoveSourceDialog(name))
+        ),
+        onHideRemoveSourceDialog: () => (
+            dispatch(SettingsActions.hideRemoveSourceDialog())
         ),
     };
 }

--- a/lib/windows/launcher/models/index.js
+++ b/lib/windows/launcher/models/index.js
@@ -49,6 +49,8 @@ const ImmutableApp = Record({
     shortcutIconPath: null,
     isOfficial: null,
     isSupportedEngine: null,
+    source: null,
+    url: null,
 });
 
 function getImmutableApp(app) {
@@ -65,6 +67,8 @@ function getImmutableApp(app) {
         shortcutIconPath: app.shortcutIconPath,
         isOfficial: app.isOfficial,
         isSupportedEngine: app.isSupportedEngine,
+        source: app.source,
+        url: app.url,
     });
 }
 

--- a/lib/windows/launcher/reducers/settingsReducer.js
+++ b/lib/windows/launcher/reducers/settingsReducer.js
@@ -34,20 +34,37 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { Record } from 'immutable';
+import { Map, Record } from 'immutable';
 import * as SettingsActions from '../actions/settingsActions';
 
 const InitialState = Record({
     shouldCheckForUpdatesAtStartup: true,
     isUpdateCheckCompleteDialogVisible: false,
     isLoading: false,
+    sources: Map({}),
+    isAddSourceDialogVisible: false,
+    isRemoveSourceDialogVisible: false,
+    removeSource: null,
 });
 
 const initialState = new InitialState();
 
 function setSettings(state, settings) {
     return state.set('isLoading', false)
-        .set('shouldCheckForUpdatesAtStartup', !!settings.shouldCheckForUpdatesAtStartup);
+        .set('shouldCheckForUpdatesAtStartup', !!settings.shouldCheckForUpdatesAtStartup)
+        .set('sources', new Map(settings.sources));
+}
+
+function addSource(state, name, url) {
+    const sources = state.get('sources');
+    const newSources = sources.set(name, url);
+    return state.set('sources', newSources);
+}
+
+function removeSource(state, name) {
+    const sources = state.get('sources');
+    const newSources = sources.delete(name);
+    return state.set('sources', newSources);
 }
 
 const reducer = (state = initialState, action) => {
@@ -64,6 +81,18 @@ const reducer = (state = initialState, action) => {
             return state.set('isUpdateCheckCompleteDialogVisible', true);
         case SettingsActions.SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE:
             return state.set('isUpdateCheckCompleteDialogVisible', false);
+        case SettingsActions.SETTINGS_SOURCE_ADDED:
+            return addSource(state, action.name, action.url);
+        case SettingsActions.SETTINGS_SOURCE_REMOVED:
+            return removeSource(state, action.name);
+        case SettingsActions.SETTINGS_ADD_SOURCE_DIALOG_SHOW:
+            return state.set('isAddSourceDialogVisible', true);
+        case SettingsActions.SETTINGS_ADD_SOURCE_DIALOG_HIDE:
+            return state.set('isAddSourceDialogVisible', false);
+        case SettingsActions.SETTINGS_REMOVE_SOURCE_DIALOG_SHOW:
+            return state.set('isRemoveSourceDialogVisible', true).set('removeSource', action.name);
+        case SettingsActions.SETTINGS_REMOVE_SOURCE_DIALOG_HIDE:
+            return state.set('isRemoveSourceDialogVisible', false).set('removeSource', null);
         default:
             return state;
     }

--- a/main/apps.js
+++ b/main/apps.js
@@ -105,7 +105,9 @@ function downloadAppsJsonFile(appsJsonUrl) {
                 'https://github.com/NordicSemiconductor/pc-nrfconnect-core');
         })
         .then(appsJson => {
-            const source = appsJson._source; // eslint-disable-line
+            // underscore is intentially used in JSON as a meta information
+            // eslint-disable-next-line no-underscore-dangle
+            const source = appsJson._source;
             if (!source && appsJsonUrl !== config.getAppsJsonUrl()) {
                 throw new Error('JSON does not contain expected `_source` tag');
             }

--- a/main/config.js
+++ b/main/config.js
@@ -51,9 +51,6 @@ let tmpDir;
 let appsRootDir;
 let appsLocalDir;
 let appsExternalDir;
-let oldNodeModulesDir;
-let oldUpdatesJsonPath;
-let oldAppsJsonPath;
 let appsJsonUrl;
 let settingsJsonPath;
 let sourcesJsonPath;
@@ -95,9 +92,6 @@ function init(argv) {
     appsRootDir = argv['apps-root-dir'] || path.join(homeDir, '.nrfconnect-apps');
     appsLocalDir = path.join(appsRootDir, 'local');
     appsExternalDir = path.join(appsRootDir, 'external');
-    oldNodeModulesDir = path.join(appsRootDir, 'node_modules');
-    oldUpdatesJsonPath = path.join(appsRootDir, 'updates.json');
-    oldAppsJsonPath = path.join(appsRootDir, 'apps.json');
     settingsJsonPath = argv['settings-json-path'] || path.join(userDataDir, 'settings.json');
     sourcesJsonPath = argv['sources-json-path'] || path.join(appsExternalDir, 'sources.json');
     appsJsonUrl = 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfconnect-core/master/apps.json';
@@ -133,9 +127,6 @@ module.exports = {
     getNodeModulesDir: source => path.join(getAppsRootDir(source), 'node_modules'),
     getUpdatesJsonPath: source => path.join(getAppsRootDir(source), 'updates.json'),
     getAppsJsonPath: source => path.join(getAppsRootDir(source), 'apps.json'),
-    getOldNodeModulesDir: () => oldNodeModulesDir,
-    getOldUpdatesJsonPath: () => oldUpdatesJsonPath,
-    getOldAppsJsonPath: () => oldAppsJsonPath,
     getSettingsJsonPath: () => settingsJsonPath,
     getSourcesJsonPath: () => sourcesJsonPath,
     getAppsJsonUrl: () => appsJsonUrl,

--- a/main/config.js
+++ b/main/config.js
@@ -57,7 +57,7 @@ let oldAppsJsonPath;
 let appsJsonUrl;
 let settingsJsonPath;
 let sourcesJsonPath;
-// let registryUrl;
+let registryUrl;
 let releaseNotesUrl;
 let skipUpdateApps;
 let skipUpdateCore;
@@ -101,7 +101,7 @@ function init(argv) {
     settingsJsonPath = argv['settings-json-path'] || path.join(userDataDir, 'settings.json');
     sourcesJsonPath = argv['sources-json-path'] || path.join(appsExternalDir, 'sources.json');
     appsJsonUrl = 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfconnect-core/master/apps.json';
-    // registryUrl = 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/';
+    registryUrl = 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/';
     releaseNotesUrl = 'https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases';
     skipUpdateApps = argv['skip-update-apps'] || false;
     skipUpdateCore = argv['skip-update-core'] || false;
@@ -139,7 +139,7 @@ module.exports = {
     getSettingsJsonPath: () => settingsJsonPath,
     getSourcesJsonPath: () => sourcesJsonPath,
     getAppsJsonUrl: () => appsJsonUrl,
-    getRegistryUrl: (source = 'official') => 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/',
+    getRegistryUrl: () => registryUrl,
     getReleaseNotesUrl: () => releaseNotesUrl,
     isSkipUpdateApps: () => skipUpdateApps,
     isSkipUpdateCore: () => skipUpdateCore,

--- a/main/config.js
+++ b/main/config.js
@@ -61,6 +61,7 @@ let skipUpdateCore;
 let skipSplashScreen;
 let officialAppName;
 let localAppName;
+let sourceName;
 
 /**
  * Init the config values based on the given command line arguments.
@@ -102,6 +103,7 @@ function init(argv) {
     skipSplashScreen = argv['skip-splash-screen'] || false;
     officialAppName = argv['open-official-app'] || null;
     localAppName = argv['open-local-app'] || null;
+    sourceName = argv.source || 'official';
 }
 
 function getAppsRootDir(source = 'official') {
@@ -137,4 +139,5 @@ module.exports = {
     isSkipSplashScreen: () => skipSplashScreen,
     getOfficialAppName: () => officialAppName,
     getLocalAppName: () => localAppName,
+    getSourceName: () => sourceName,
 };

--- a/main/config.js
+++ b/main/config.js
@@ -50,12 +50,14 @@ let desktopDir;
 let tmpDir;
 let appsRootDir;
 let appsLocalDir;
-let nodeModulesDir;
-let updatesJsonPath;
-let appsJsonPath;
+let appsExternalDir;
+let oldNodeModulesDir;
+let oldUpdatesJsonPath;
+let oldAppsJsonPath;
 let appsJsonUrl;
 let settingsJsonPath;
-let registryUrl;
+let sourcesJsonPath;
+// let registryUrl;
 let releaseNotesUrl;
 let skipUpdateApps;
 let skipUpdateCore;
@@ -92,18 +94,27 @@ function init(argv) {
     tmpDir = electronApp.getPath('temp');
     appsRootDir = argv['apps-root-dir'] || path.join(homeDir, '.nrfconnect-apps');
     appsLocalDir = path.join(appsRootDir, 'local');
-    nodeModulesDir = path.join(appsRootDir, 'node_modules');
-    updatesJsonPath = path.join(appsRootDir, 'updates.json');
-    appsJsonPath = path.join(appsRootDir, 'apps.json');
+    appsExternalDir = path.join(appsRootDir, 'external');
+    oldNodeModulesDir = path.join(appsRootDir, 'node_modules');
+    oldUpdatesJsonPath = path.join(appsRootDir, 'updates.json');
+    oldAppsJsonPath = path.join(appsRootDir, 'apps.json');
     settingsJsonPath = argv['settings-json-path'] || path.join(userDataDir, 'settings.json');
+    sourcesJsonPath = argv['sources-json-path'] || path.join(appsExternalDir, 'sources.json');
     appsJsonUrl = 'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfconnect-core/master/apps.json';
-    registryUrl = 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/';
+    // registryUrl = 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/';
     releaseNotesUrl = 'https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases';
     skipUpdateApps = argv['skip-update-apps'] || false;
     skipUpdateCore = argv['skip-update-core'] || false;
     skipSplashScreen = argv['skip-splash-screen'] || false;
     officialAppName = argv['open-official-app'] || null;
     localAppName = argv['open-local-app'] || null;
+}
+
+function getAppsRootDir(source = 'official') {
+    if (source === 'official') {
+        return appsRootDir;
+    }
+    return path.join(appsExternalDir, source);
 }
 
 module.exports = {
@@ -116,19 +127,23 @@ module.exports = {
     getUserDataDir: () => userDataDir,
     getDesktopDir: () => desktopDir,
     getTmpDir: () => tmpDir,
-    getAppsRootDir: () => appsRootDir,
+    getAppsRootDir,
     getAppsLocalDir: () => appsLocalDir,
-    getNodeModulesDir: () => nodeModulesDir,
-    getUpdatesJsonPath: () => updatesJsonPath,
-    getAppsJsonPath: () => appsJsonPath,
+    getAppsExternalDir: () => appsExternalDir,
+    getNodeModulesDir: source => path.join(getAppsRootDir(source), 'node_modules'),
+    getUpdatesJsonPath: source => path.join(getAppsRootDir(source), 'updates.json'),
+    getAppsJsonPath: source => path.join(getAppsRootDir(source), 'apps.json'),
+    getOldNodeModulesDir: () => oldNodeModulesDir,
+    getOldUpdatesJsonPath: () => oldUpdatesJsonPath,
+    getOldAppsJsonPath: () => oldAppsJsonPath,
     getSettingsJsonPath: () => settingsJsonPath,
+    getSourcesJsonPath: () => sourcesJsonPath,
     getAppsJsonUrl: () => appsJsonUrl,
-    getRegistryUrl: () => registryUrl,
+    getRegistryUrl: (source = 'official') => 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/',
     getReleaseNotesUrl: () => releaseNotesUrl,
     isSkipUpdateApps: () => skipUpdateApps,
     isSkipUpdateCore: () => skipUpdateCore,
     isSkipSplashScreen: () => skipSplashScreen,
     getOfficialAppName: () => officialAppName,
     getLocalAppName: () => localAppName,
-
 };

--- a/main/fileUtil.js
+++ b/main/fileUtil.js
@@ -161,6 +161,33 @@ function deleteDir(folderPath) {
 }
 
 /**
+ * Move file or directory to new path.
+ *
+ * @param {string} pathToMove the path of file or directory to move.
+ * @param {string} pathToMoveTo the path of destination directory.
+ * @returns {Promise} promise that resolves if successful.
+ */
+function moveIfExists(pathToMove, pathToMoveTo) {
+    return new Promise((resolve, reject) => {
+        const from = path.resolve(pathToMove);
+        const to = path.join(path.resolve(pathToMoveTo), path.basename(from));
+        fs.stat(from, err => {
+            if (err) {
+                resolve();
+            } else {
+                fs.rename(from, to, error => {
+                    if (error) {
+                        reject(new Error(`Unable to move ${pathToMove}: ${error.message}`));
+                    } else {
+                        resolve();
+                    }
+                });
+            }
+        });
+    });
+}
+
+/**
  * Copy files from source to destination
  *
  * @param {string} src the path to source.
@@ -320,6 +347,7 @@ module.exports = {
     listFiles,
     deleteFile,
     deleteDir,
+    moveIfExists,
     copy,
     copyFromAsar,
     chmodDir,

--- a/main/fileUtil.js
+++ b/main/fileUtil.js
@@ -161,33 +161,6 @@ function deleteDir(folderPath) {
 }
 
 /**
- * Move file or directory to new path.
- *
- * @param {string} pathToMove the path of file or directory to move.
- * @param {string} pathToMoveTo the path of destination directory.
- * @returns {Promise} promise that resolves if successful.
- */
-function moveIfExists(pathToMove, pathToMoveTo) {
-    return new Promise((resolve, reject) => {
-        const from = path.resolve(pathToMove);
-        const to = path.join(path.resolve(pathToMoveTo), path.basename(from));
-        fs.stat(from, err => {
-            if (err) {
-                resolve();
-            } else {
-                fs.rename(from, to, error => {
-                    if (error) {
-                        reject(new Error(`Unable to move ${pathToMove}: ${error.message}`));
-                    } else {
-                        resolve();
-                    }
-                });
-            }
-        });
-    });
-}
-
-/**
  * Copy files from source to destination
  *
  * @param {string} src the path to source.
@@ -347,7 +320,6 @@ module.exports = {
     listFiles,
     deleteFile,
     deleteDir,
-    moveIfExists,
     copy,
     copyFromAsar,
     chmodDir,

--- a/main/registryApi.js
+++ b/main/registryApi.js
@@ -41,8 +41,8 @@ const shasum = require('shasum');
 const config = require('./config');
 const net = require('./net');
 
-function getPackageUrl(name) {
-    const registryUrl = config.getRegistryUrl();
+function getPackageUrl(name, regUrl) {
+    const registryUrl = regUrl || config.getRegistryUrl();
     return url.resolve(registryUrl, name);
 }
 
@@ -50,8 +50,8 @@ function getLatestFromPackageInfo(packageInfo) {
     return packageInfo['dist-tags'].latest;
 }
 
-function getPackageInfo(name) {
-    return net.downloadToJson(getPackageUrl(name));
+function getPackageInfo(name, regUrl) {
+    return net.downloadToJson(getPackageUrl(name, regUrl));
 }
 
 /**
@@ -64,8 +64,8 @@ function getPackageInfo(name) {
  * @param {string} version either a semver version or 'latest'.
  * @returns {Promise} promise that resolves with the dist object.
  */
-function getDistInfo(name, version) {
-    return getPackageInfo(name)
+function getDistInfo(name, version, regUrl) {
+    return getPackageInfo(name, regUrl)
         .then(packageInfo => {
             let versionToInstall;
             if (version === 'latest') {
@@ -105,8 +105,8 @@ function verifyShasum(filePath, expectedShasum) {
  * @param {string} destinationDir full path to the destination directory.
  * @returns {Promise} promise that resolves with path to the downloaded file.
  */
-function downloadTarball(name, version, destinationDir) {
-    return getDistInfo(name, version)
+function downloadTarball(name, version, destinationDir, regUrl) {
+    return getDistInfo(name, version, regUrl)
         .then(distInfo => {
             if (!distInfo.tarball) {
                 return Promise.reject(`No tarball found for ${name}@${version}`);

--- a/main/settings.js
+++ b/main/settings.js
@@ -40,9 +40,9 @@ const fs = require('fs');
 const config = require('./config');
 
 let data = null;
+let sourcesData = null;
 
-function parseSettingsFile() {
-    const filePath = config.getSettingsJsonPath();
+function parseJSONFile(filePath) {
     if (!fs.existsSync(filePath)) {
         return {};
     }
@@ -58,7 +58,7 @@ function load() {
     if (data !== null) {
         return;
     }
-    const settings = parseSettingsFile();
+    const settings = parseJSONFile(config.getSettingsJsonPath());
     if (settings && typeof settings === 'object') {
         data = settings;
     } else {
@@ -66,14 +66,32 @@ function load() {
     }
 }
 
-function save() {
+function saveSettings() {
     fs.writeFileSync(config.getSettingsJsonPath(), JSON.stringify(data));
+}
+
+function loadSources() {
+    if (sourcesData !== null) {
+        return;
+    }
+    let sources = parseJSONFile(config.getSourcesJsonPath());
+    if (!sources || typeof sources !== 'object') {
+        sources = {};
+    }
+    sourcesData = {
+        ...sources,
+        official: config.getAppsJsonUrl(),
+    };
+}
+
+function saveSources() {
+    fs.writeFileSync(config.getSourcesJsonPath(), JSON.stringify(sourcesData));
 }
 
 exports.set = (key, value) => {
     load();
     data[key] = value;
-    save();
+    saveSettings();
 };
 
 exports.get = key => {
@@ -87,11 +105,22 @@ exports.get = key => {
     return value;
 };
 
+exports.setSources = sources => {
+    loadSources();
+    sourcesData = sources;
+    saveSources();
+};
+
+exports.getSources = () => {
+    loadSources();
+    return sourcesData;
+};
+
 exports.unset = key => {
     load();
     if (key in data) {
         delete data[key];
-        save();
+        saveSettings();
     }
 };
 

--- a/main/settings.js
+++ b/main/settings.js
@@ -66,7 +66,7 @@ function load() {
     }
 }
 
-function saveSettings() {
+function save() {
     fs.writeFileSync(config.getSettingsJsonPath(), JSON.stringify(data));
 }
 
@@ -91,7 +91,7 @@ function saveSources() {
 exports.set = (key, value) => {
     load();
     data[key] = value;
-    saveSettings();
+    save();
 };
 
 exports.get = key => {
@@ -120,7 +120,7 @@ exports.unset = key => {
     load();
     if (key in data) {
         delete data[key];
-        saveSettings();
+        save();
     }
 };
 

--- a/main/settings.js
+++ b/main/settings.js
@@ -42,7 +42,7 @@ const config = require('./config');
 let data = null;
 let sourcesData = null;
 
-function parseJSONFile(filePath) {
+function parseJsonFile(filePath) {
     if (!fs.existsSync(filePath)) {
         return {};
     }
@@ -58,7 +58,7 @@ function load() {
     if (data !== null) {
         return;
     }
-    const settings = parseJSONFile(config.getSettingsJsonPath());
+    const settings = parseJsonFile(config.getSettingsJsonPath());
     if (settings && typeof settings === 'object') {
         data = settings;
     } else {
@@ -74,7 +74,7 @@ function loadSources() {
     if (sourcesData !== null) {
         return;
     }
-    let sources = parseJSONFile(config.getSourcesJsonPath());
+    let sources = parseJsonFile(config.getSourcesJsonPath());
     if (!sources || typeof sources !== 'object') {
         sources = {};
     }

--- a/main/windows.js
+++ b/main/windows.js
@@ -121,15 +121,17 @@ function openAppWindow(app) {
     });
 }
 
-function openOfficialAppWindow(appName) {
+function openOfficialAppWindow(appName, sourceName) {
     return apps.getOfficialApps()
         .then(appList => {
-            const officialApp = appList.find(app => app.name === appName);
+            const officialApp = appList.find(app => (
+                app.name === appName && app.source === sourceName
+            ));
             const isInstalled = officialApp && officialApp.path;
             if (isInstalled) {
                 openAppWindow(officialApp);
             } else {
-                throw new Error(`Tried to open official app ${appName}, but it is not installed`);
+                throw new Error(`Tried to open app ${appName} from source ${sourceName}, but it is not installed`);
             }
         });
 }

--- a/resources/css/launcher.less
+++ b/resources/css/launcher.less
@@ -97,9 +97,9 @@ html, body, #webapp {
 .core-app-management-item {
     width: 100%;
 
-    .list-group-item-heading-sourcetag:before { content: "[" }
-    .list-group-item-heading-sourcetag:after { content: "]" }
-    .list-group-item-heading-sourcetag {
+    .list-group-item-heading-source-tag:before { content: "[" }
+    .list-group-item-heading-source-tag:after { content: "]" }
+    .list-group-item-heading-source-tag {
         font-style: italic;
         font-size: smaller;
         padding: 4px 10px;

--- a/resources/css/launcher.less
+++ b/resources/css/launcher.less
@@ -97,6 +97,14 @@ html, body, #webapp {
 .core-app-management-item {
     width: 100%;
 
+    .list-group-item-heading-sourcetag:before { content: "[" }
+    .list-group-item-heading-sourcetag:after { content: "]" }
+    .list-group-item-heading-sourcetag {
+        font-style: italic;
+        font-size: smaller;
+        padding: 4px 10px;
+    }
+
     .core-app-management-item-footer {
         display: flex;
         width: 100%;
@@ -159,11 +167,38 @@ html, body, #webapp {
     border: 1px solid lightgray;
     background-color: white;
     border-radius: 4px;
+    margin-bottom: 10px;
 }
 
 .core-settings-update-check-controls {
     display: flex;
     justify-content: space-between;
+}
+.core-settings-sources-controls {
+    display: flex;
+    justify-content: flex-end;
+}
+
+table.core-settings-sources {
+    table-layout: fixed;
+    width: 100%;
+    margin-bottom: 10px;
+}
+
+.core-settings-source {
+    .core-settings-source-name {
+        width: 20%;
+        white-space: nowrap;
+        font-weight: bold;
+    }
+    .core-settings-source-url {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .core-settings-source-remove {
+        width: 90px;
+    }
 }
 
 .core-dropdown .dropdown-menu {


### PR DESCRIPTION
This PR adds a new section to the the _SettingsView_ where users can add multiple _apps.json_ URLs for external app sources. nRFConnect creates a new directory `.nrfconnect-apps/external` which will be the root of storing these apps.
There's an extra requirement for any additional _apps.json_, to specify `_source` string member as the source name which will create a new directory under `external`.
New command line argument `source` has been introduced to be able to specify the source which works together with `open-official-app`. This change is also added to desktop shortcuts.
Jest tests and snapshots are updated.