### PR TITLE
Update electron to 2.0.11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
-target = 2.0.6
+target = 2.0.11
 disturl = https://atom.io/download/electron

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "asar": "0.13.0",
         "babel-polyfill": "6.23.0",
         "bootstrap": "3.3.7",
-        "electron": "2.0.6",
+        "electron": "2.0.11",
         "electron-builder": "19.53.6",
         "electron-is-dev": "0.1.2",
         "moment": "2.18.1",


### PR DESCRIPTION
Electron versions <2.0.8 fail on various distributions due to glibc 2.28:

 * Ubuntu 18.10 beta
 * Fedora 29 beta

Some of these distributions will likely patch patch glibc to avoid this
behaviour, but Fedora 29 doesn't seem like it will go this route, and
I'm not yet sure about Ubuntu.

Simply updating electron to 2.0.8+ solves the problem. I chose the most
recent one, but I could go back down to 2.0.8, but I'm not sure why
you'd want to.