### PR TITLE
Support displaying multiple serialports and board version of a device

### DIFF
--- a/lib/windows/app/components/DeviceSelector.jsx
+++ b/lib/windows/app/components/DeviceSelector.jsx
@@ -45,6 +45,19 @@ import Dropdown from '../../../components/HotkeyedDropdown';
 
 // Stateless, templating-only component. Used only from ../containers/DeviceSelectorContainer
 export default class DeviceSelector extends React.Component {
+    /**
+     * Returns an array of JSX that corresponds to the list of serialports
+     * of a device definition from nrf-device-lister
+     *
+     * @param {Object} device The device to render as a menu item.
+     * @returns {*} Array of 'serialport: ...' JSX item
+     */
+    static mapSerialPortsToListItems(device) {
+        return Object.keys(device)
+            .filter(key => key.startsWith('serialport'))
+            .map(key => <li key={device[key].comName}>Serial port: {device[key].comName}</li>);
+    }
+
     componentDidMount() {
         this.props.onMount();
     }
@@ -98,11 +111,12 @@ export default class DeviceSelector extends React.Component {
                 className={menuItemCssClass}
                 onSelect={() => onSelect(device)}
             >
-                <div>{ device.serialNumber }</div>
+                <div>
+                    { device.serialNumber }
+                    <span>{ device.boardVersion }</span>
+                </div>
                 <ul className={menuItemDetailsCssClass}>
-                    { device.serialport ?
-                        (<li>Serial port: {device.serialport.comName}</li>)
-                        : null }
+                    { DeviceSelector.mapSerialPortsToListItems(device) }
                     { device.usb ?
                         (<li>USB: {device.usb.manufacturer} {device.usb.product}</li>)
                         : null }
@@ -190,4 +204,3 @@ DeviceSelector.defaultProps = {
     onMount: () => {},
     onUnmount: () => {},
 };
-

--- a/lib/windows/app/components/__tests__/DeviceSelector-test.jsx
+++ b/lib/windows/app/components/__tests__/DeviceSelector-test.jsx
@@ -73,10 +73,14 @@ describe('DeviceSelector', () => {
                         serialport: {
                             comName: '/dev/ttyACM0',
                         },
+                        'serialport.1': {
+                            comName: '/dev/ttyACM1',
+                        },
                         usb: {
                             manufacturer: 'Nordic Semiconductor',
                             product: 'nRF52 USB',
                         },
+                        boardVersion: 'PCA42424',
                         traits: ['serialport', 'nordicUsb', 'jlink'],
                     },
                 ]}

--- a/lib/windows/app/components/__tests__/__snapshots__/DeviceSelector-test.jsx.snap
+++ b/lib/windows/app/components/__tests__/__snapshots__/DeviceSelector-test.jsx.snap
@@ -45,6 +45,9 @@ exports[`DeviceSelector should render one device with serialport, usb, and jlink
     >
       <div>
         123456789
+        <span>
+          PCA42424
+        </span>
       </div>
       <ul
         className="core-device-selector-item-details"
@@ -52,6 +55,10 @@ exports[`DeviceSelector should render one device with serialport, usb, and jlink
         <li>
           Serial port: 
           /dev/ttyACM0
+        </li>
+        <li>
+          Serial port: 
+          /dev/ttyACM1
         </li>
         <li>
           USB: 

--- a/resources/css/app.less
+++ b/resources/css/app.less
@@ -91,6 +91,11 @@ html, body, #webapp {
 
 .core-device-selector-item {
     padding-left: 5px;
+
+    // board version
+    > a > div:nth-child(1) > span {
+        margin-left: 20px;
+    }
 }
 
 ul.core-device-selector-item-details {


### PR DESCRIPTION
With this PR the _DeviceSelector_ component can displays multiple serial ports of a single device, and for better distinction of different devices the board version is also displayed next to the serial number.