### PR TITLE
Update info about bug reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ In order to access Nordic USB devices with correct permissions *udev* rules need
 
 # Contributing
 
-Feel free to file code related issues on [GitHub Issues](https://github.com/NordicSemiconductor/pc-nrfconnect-core/issues) and/or submit a pull request. In order to accept your pull request, we need you to sign our Contributor License Agreement (CLA). You will see instructions for doing this after having submitted your first pull request. You only need to sign the CLA once, so if you have already done it for another project in the NordicSemiconductor organization, you are good to go.
+Feel free to submit a pull request. In order to accept your pull request, we need you to sign our Contributor License Agreement (CLA). You will see instructions for doing this after having submitted your first pull request. You only need to sign the CLA once, so if you have already done it for another project in the NordicSemiconductor organization, you are good to go.
+
+# Reporting bugs
+
+If you find any bugs, or have questions or other feedback, please submit this via a post on the [Nordic DevZone Questions](http://devzone.nordicsemi.no) portal.
+Bug reports should include sufficient details about the necessary steps to reproduce the bug.
 
 # Building from source
 
@@ -184,8 +189,3 @@ nRF Connect builds on top of other sub components that live in their own GitHub 
 # License
 
 See the [license file](LICENSE) for details.
-
-# Feedback
-
-* Ask questions on [DevZone Questions](https://devzone.nordicsemi.com)
-* File code related issues on [GitHub Issues](https://github.com/NordicSemiconductor/pc-nrfconnect-core/issues)

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Feel free to submit a pull request. In order to accept your pull request, we nee
 
 # Reporting bugs
 
-If you find any bugs, or have questions or other feedback, please submit this via a post on the [Nordic DevZone Questions](http://devzone.nordicsemi.no) portal.
-Bug reports should include sufficient details about the necessary steps to reproduce the bug.
+If you find any bugs, or have questions or other feedback in general, please submit a post on the [Nordic DevZone](http://devzone.nordicsemi.no) portal.
+Note that bug reports should describe in sufficient detail how to reproduce the bug.
 
 # Building from source
 


### PR DESCRIPTION
Update information about where to report bugs and feedback. Instead of using *github issues* we would like users to instead use Nordic DevZone for all bug reports and feedback. We believe users will receive faster follow up on DevZone as it backed by tech support and a large community of users. Reports that cannot be handled by tech support directly will as usual be escalated and forwarded to the developers.