### PR TITLE
Add module support for nrf-usb and nrf-device-setup

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -34,7 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import SerialPort from 'serialport';
+import serialPort from 'serialport';
 import bleDriverJs from 'pc-ble-driver-js';
 import nrfjprog from 'pc-nrfjprog-js';
 import usb from 'nrf-usb';
@@ -48,9 +48,8 @@ core.logger = logger;
 export default {
     bleDriver,
     nrfjprog,
-    SerialPort,
     usb,
-    'nrf-usb': usb,
+    serialPort,
     logger,
     electron,
     core,

--- a/lib/windows/app/index.js
+++ b/lib/windows/app/index.js
@@ -41,6 +41,7 @@ import electron from 'electron';
 import * as ReactRedux from 'react-redux';
 import ReactDOM, { render } from 'react-dom';
 import Module from 'module';
+import DeviceSetup from 'nrf-device-setup';
 import RootContainer from './containers/RootContainer';
 import configureStore from '../../store/configureStore';
 import { initAppDirectories, getAppLogDir, loadApp, invokeAppFn } from '../../util/apps';
@@ -59,12 +60,13 @@ Module._load = function load(modulePath) { // eslint-disable-line no-underscore-
         react: React,
         'react-dom': ReactDOM,
         'react-redux': ReactRedux,
+        'nrf-device-setup': DeviceSetup,
 
+        serialport: api.serialPort,
+        electron: api.electron,
         'pc-ble-driver-js': api.bleDriver,
         'pc-nrfjprog-js': api.nrfjprog,
-        serialport: api.SerialPort,
-        electron: api.electron,
-        usb: api.usb,
+        'nrf-usb': api.usb,
 
         'nrfconnect/core': api.core,
     };


### PR DESCRIPTION
This PR is due to including nrf-usb and nrf-device-setup into pc-nrfconnect-core so that apps dont need to have duplicated dependencies.