### PR TITLE
Splitter elements allow resizable LogViewer and SidePanel

### DIFF
--- a/lib/windows/app/actions/logActions.js
+++ b/lib/windows/app/actions/logActions.js
@@ -81,6 +81,10 @@ export const CLEAR_ENTRIES = 'LOG_CLEAR_ENTRIES';
  */
 export const TOGGLE_AUTOSCROLL = 'LOG_TOGGLE_AUTOSCROLL';
 
+/**
+ * Indicates that log container resize has been requested.
+ */
+export const RESIZE_LOG_CONTAINER = 'LOG_RESIZE_LOG_CONTAINER';
 
 const LOG_UPDATE_INTERVAL = 400;
 let logListenerTimeout;
@@ -120,6 +124,13 @@ function clearEntriesAction() {
 function toggleAutoScrollAction() {
     return {
         type: TOGGLE_AUTOSCROLL,
+    };
+}
+
+function resizeLogContainerAction(containerHeight) {
+    return {
+        type: RESIZE_LOG_CONTAINER,
+        containerHeight,
     };
 }
 
@@ -163,6 +174,10 @@ export function openLogFile() {
 
 export function toggleAutoScroll() {
     return toggleAutoScrollAction();
+}
+
+export function resizeLogContainer(containerHeight) {
+    return resizeLogContainerAction(containerHeight);
 }
 
 export function clear() {

--- a/lib/windows/app/components/LogViewer.jsx
+++ b/lib/windows/app/components/LogViewer.jsx
@@ -63,10 +63,12 @@ class LogViewer extends React.Component {
             logEntries,
             containerHeight,
             elementHeight,
-            infiniteLoadBeginEdgeOffset,
             cssClass,
             infiniteLogCssClass,
         } = this.props;
+
+        const infiniteLoadBeginEdgeOffset =
+            Math.max(containerHeight - elementHeight, elementHeight);
 
         return (
             <div className={cssClass}>
@@ -95,7 +97,6 @@ LogViewer.propTypes = {
     autoScroll: PropTypes.bool.isRequired,
     containerHeight: PropTypes.number,
     elementHeight: PropTypes.number,
-    infiniteLoadBeginEdgeOffset: PropTypes.number,
     cssClass: PropTypes.string,
     infiniteLogCssClass: PropTypes.string,
 };
@@ -105,7 +106,6 @@ LogViewer.defaultProps = {
     onUnmount: null,
     containerHeight: 155,
     elementHeight: 20,
-    infiniteLoadBeginEdgeOffset: 135,
     cssClass: 'core-log-viewer',
     infiniteLogCssClass: 'core-infinite-log',
 };

--- a/lib/windows/app/components/Root.jsx
+++ b/lib/windows/app/components/Root.jsx
@@ -47,13 +47,65 @@ import { decorate } from '../../../util/apps';
 
 const DecoratedNavBar = decorate(NavBar, 'NavBar');
 
+function onMouseDownHorizontal(event) {
+    event.preventDefault();
+    const splitter = document.querySelector('.core-splitter.horizontal');
+    const targetNode = document.querySelector('.core-infinite-log');
+    const initial = targetNode.offsetHeight + event.clientY;
+    const originalMouseMove = document.onmousemove;
+    const originalMouseUp = document.onmouseup;
+    splitter.draggable = true;
+    document.onmousemove = e => {
+        e.preventDefault();
+        targetNode.style.height = `${initial - e.clientY}px`;
+    };
+    document.onmouseup = e => {
+        e.preventDefault();
+        document.onmousemove = originalMouseMove;
+        document.onmouseup = originalMouseUp;
+        splitter.draggable = false;
+    };
+}
+
+function onMouseDownVertical(event) {
+    event.preventDefault();
+    const splitter = document.querySelector('.core-splitter.vertical');
+    const targetNode = splitter.parentNode.nextSibling;
+    const initial = targetNode.offsetWidth + event.clientX;
+    const originalMouseMove = document.onmousemove;
+    const originalMouseUp = document.onmouseup;
+    splitter.draggable = true;
+    document.onmousemove = e => {
+        e.preventDefault();
+        targetNode.style.flexBasis = `${initial - e.clientX}px`;
+    };
+    document.onmouseup = e => {
+        e.preventDefault();
+        document.onmousemove = originalMouseMove;
+        document.onmouseup = originalMouseUp;
+        splitter.draggable = false;
+    };
+}
+
 const Root = () => (
     <div className="core-main-area">
         <DecoratedNavBar />
         <div className="core-main-layout">
             <div>
                 <MainViewContainer />
+                <div
+                    tabIndex={-1}
+                    role="button"
+                    className="core-splitter horizontal"
+                    onMouseDown={onMouseDownHorizontal}
+                />
                 <LogViewerContainer />
+                <div
+                    tabIndex={-1}
+                    role="button"
+                    className="core-splitter vertical"
+                    onMouseDown={onMouseDownVertical}
+                />
             </div>
             <SidePanelContainer />
         </div>

--- a/lib/windows/app/components/Root.jsx
+++ b/lib/windows/app/components/Root.jsx
@@ -35,6 +35,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import NavBar from './NavBar';
 import SidePanelContainer from '../containers/SidePanelContainer';
 import LogViewerContainer from '../containers/LogViewerContainer';
@@ -47,7 +48,7 @@ import { decorate } from '../../../util/apps';
 
 const DecoratedNavBar = decorate(NavBar, 'NavBar');
 
-function onMouseDownHorizontal(event) {
+function onMouseDownHorizontal(event, resizeLogContainer) {
     event.preventDefault();
     const splitter = document.querySelector('.core-splitter.horizontal');
     const targetNode = document.querySelector('.core-infinite-log');
@@ -64,6 +65,7 @@ function onMouseDownHorizontal(event) {
         document.onmousemove = originalMouseMove;
         document.onmouseup = originalMouseUp;
         splitter.draggable = false;
+        resizeLogContainer(targetNode.offsetHeight);
     };
 }
 
@@ -87,7 +89,7 @@ function onMouseDownVertical(event) {
     };
 }
 
-const Root = () => (
+const Root = ({ resizeLogContainer }) => (
     <div className="core-main-area">
         <DecoratedNavBar />
         <div className="core-main-layout">
@@ -97,7 +99,7 @@ const Root = () => (
                     tabIndex={-1}
                     role="button"
                     className="core-splitter horizontal"
-                    onMouseDown={onMouseDownHorizontal}
+                    onMouseDown={event => onMouseDownHorizontal(event, resizeLogContainer)}
                 />
                 <LogViewerContainer />
                 <div
@@ -115,5 +117,9 @@ const Root = () => (
         <ErrorDialogContainer />
     </div>
 );
+
+Root.propTypes = {
+    resizeLogContainer: PropTypes.func.isRequired,
+};
 
 export default Root;

--- a/lib/windows/app/containers/LogViewerContainer.js
+++ b/lib/windows/app/containers/LogViewerContainer.js
@@ -44,6 +44,7 @@ function mapStateToProps(state) {
     return {
         logEntries: log.entries,
         autoScroll: log.autoScroll,
+        containerHeight: log.containerHeight,
     };
 }
 

--- a/lib/windows/app/containers/RootContainer.js
+++ b/lib/windows/app/containers/RootContainer.js
@@ -38,9 +38,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import Root from '../components/Root';
+import { resizeLogContainer } from '../actions/logActions';
 
 const RootContainer = ({ store }) => (
-    React.createElement(Provider, { store }, React.createElement(Root))
+    React.createElement(Provider, { store },
+        React.createElement(Root, {
+            resizeLogContainer: (...args) => store.dispatch(resizeLogContainer(...args)),
+        }),
+    )
 );
 
 RootContainer.propTypes = {

--- a/lib/windows/app/reducers/logReducer.js
+++ b/lib/windows/app/reducers/logReducer.js
@@ -40,6 +40,7 @@ import * as LogAction from '../actions/logActions';
 const InitialState = Record({
     autoScroll: true,
     entries: List(),
+    containerHeight: 155,
 });
 
 const initialState = new InitialState();
@@ -52,6 +53,8 @@ const reducer = (state = initialState, action) => {
             return state.set('entries', state.entries.clear());
         case LogAction.TOGGLE_AUTOSCROLL:
             return state.set('autoScroll', !state.autoScroll);
+        case LogAction.RESIZE_LOG_CONTAINER:
+            return state.set('containerHeight', action.containerHeight);
         default:
             return state;
     }

--- a/resources/css/app.less
+++ b/resources/css/app.less
@@ -26,6 +26,8 @@ html, body, #webapp {
         display: flex;
         flex-flow: column;
         min-width: 0;
+        position: relative;
+        padding-right: 3px;
 
         // main view
         > div:nth-child(1) {
@@ -35,11 +37,21 @@ html, body, #webapp {
             overflow: hidden;
         }
 
+        // horizontal splitter
+        > div:nth-child(2) {}
+
         // log viewer
-        > div:nth-child(2) {
+        > div:nth-child(3) {
             border-top: 1px solid gray;
             overflow: hidden;
             width: 100%;
+        }
+
+        // vertical splitter
+        > div:nth-child(4) {
+            position: absolute;
+            right: 0;
+            height: 100%;
         }
     }
 
@@ -51,6 +63,24 @@ html, body, #webapp {
         border-left: 1px solid gray;
         overflow-y: auto;
     }
+}
+
+.core-splitter {
+    min-width: 3px;
+    min-height: 3px;
+    background-color: lightgray;
+    transition: background-color 0.5s linear;
+}
+
+.core-splitter:hover {
+    background-color: darken(lightgray, 30%);
+}
+.core-splitter.horizontal {
+    cursor: row-resize;
+}
+.core-splitter.vertical {
+    border-top: 1px solid gray;
+    cursor: col-resize;
 }
 
 .core-nav-bar {


### PR DESCRIPTION
This PR introduces a horizontal and a vertical splitter element in the main area which separates the _MainView_ from _LogViewer_ and from _SidePanel_. These elements are draggable which allows the user to resize the latter components.

In order to resize the _LogViewer_, a redux flow had to be added to inform the infinite-log about the new container height.

Apps are not effected by the functionality (so far they all work as expected), however styles might be slightly effected, at least redundant CSS rules need to be deleted in BLE app.