### PR TITLE
Fix log performance by limiting entries in LogViewer

### DIFF
--- a/lib/windows/app/reducers/logReducer.js
+++ b/lib/windows/app/reducers/logReducer.js
@@ -37,6 +37,8 @@
 import { Record, List } from 'immutable';
 import * as LogAction from '../actions/logActions';
 
+const MAX_ENTRIES = 10000;
+
 const InitialState = Record({
     autoScroll: true,
     entries: List(),
@@ -47,8 +49,18 @@ const initialState = new InitialState();
 
 const reducer = (state = initialState, action) => {
     switch (action.type) {
-        case LogAction.ADD_ENTRIES:
-            return state.set('entries', state.entries.push(...(action.entries)));
+        case LogAction.ADD_ENTRIES: {
+            let newEntries = state.entries.push(...(action.entries));
+            if (newEntries.size > MAX_ENTRIES) {
+                newEntries = newEntries.slice(-MAX_ENTRIES).unshift({
+                    id: -1,
+                    level: 'info',
+                    time: new Date(),
+                    message: 'The log in this view has been shortened. Open the log file to see the full content.',
+                });
+            }
+            return state.set('entries', newEntries);
+        }
         case LogAction.CLEAR_ENTRIES:
             return state.set('entries', state.entries.clear());
         case LogAction.TOGGLE_AUTOSCROLL:


### PR DESCRIPTION
This PR limits the number of entries in the _LogViewer_ to 10000, and prepends a user friendly message about the full log which appears always on the first line should the user scroll back.