### PR TITLE
Add copy-to-clipboard to source url and make it selectable as well

### DIFF
--- a/lib/windows/launcher/components/SettingsView.jsx
+++ b/lib/windows/launcher/components/SettingsView.jsx
@@ -37,10 +37,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox, Button } from 'react-bootstrap';
+import { clipboard } from 'electron';
 import moment from 'moment';
 import UpdateCheckCompleteDialog from './UpdateCheckCompleteDialog';
 import InputLineDialog from './InputLineDialog';
 import ConfirmRemoveSourceDialog from '../containers/ConfirmRemoveSourceDialog';
+
+const CopyToClipboard = ({ text }) => (
+    <Button
+        bsSize="small"
+        className="glyphicon glyphicon-copy"
+        title="Copy to clipboard"
+        onClick={() => clipboard.writeText(text)}
+    />
+);
+
+CopyToClipboard.propTypes = {
+    text: PropTypes.string.isRequired,
+};
 
 function cancel(event) {
     event.preventDefault();
@@ -151,8 +165,11 @@ class SettingsView extends React.Component {
                                     .map(name => (
                                         <tr key={name} className="core-settings-source">
                                             <td className="core-settings-source-name">{name}</td>
+                                            <td className="core-settings-copy-to-clipboard">
+                                                <CopyToClipboard text={sourcesJS[name]} />
+                                            </td>
                                             <td
-                                                className="core-settings-source-url"
+                                                className="core-settings-source-url selectable"
                                                 title={sourcesJS[name]}
                                             >
                                                 {sourcesJS[name]}

--- a/resources/css/common/styles.less
+++ b/resources/css/common/styles.less
@@ -77,3 +77,7 @@ body {
 :focus {
     outline-color: @gray-medium-lighter !important;
 }
+
+.selectable {
+    user-select: initial;
+}

--- a/resources/css/launcher.less
+++ b/resources/css/launcher.less
@@ -195,9 +195,18 @@ table.core-settings-sources {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding-right: 8px;
     }
     .core-settings-source-remove {
-        width: 90px;
+        width: 84px;
+        text-align: right;
+    }
+
+    .core-settings-copy-to-clipboard {
+        width: 34px;
+        button {
+            padding: 2px 6px;
+        }
     }
 }
 


### PR DESCRIPTION
This PR introduces a button next to the source URL in the Settings tab that copies the URL to the clipboard. The URL's style is also updated to allow selection.