### PR TITLE
Remove nRF Connect for Cloud Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ The following apps have been created for nRF Connect;
 * [Power Profiler](https://www.npmjs.com/package/pc-nrfconnect-ppk)
 * [Programmer](https://www.npmjs.com/package/pc-nrfconnect-programmer)
 * [RSSI Viewer](https://www.npmjs.com/package/pc-nrfconnect-rssi)
-* [nRF Cloud Gateway](https://www.npmjs.com/package/nrf-cloud-gateway)
 
 ## Automatic installation of apps
 

--- a/apps.json
+++ b/apps.json
@@ -9,11 +9,6 @@
         "description": "Live visualization of RSSI per frequency for nRF52832",
         "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-rssi"
     },
-    "nrfcloud-gateway": {
-        "displayName": "nRF Cloud Gateway (experimental)",
-        "description": "nRF Cloud Gateway, connecting BLE to the cloud. This is an experimental app that may be deprecated.",
-        "homepage": "https://www.nrfcloud.com"
-    },
     "pc-nrfconnect-ppk": {
         "displayName": "Power Profiler",
         "description": "Tool to measure current for nRF5x applications",


### PR DESCRIPTION
The PC version of the gateway is no longer maintained and supported.

Please use the Cordova Gateway: https://github.com/nRFCloud/gateway-cordova