### PR TITLE
Disable x64 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,9 +19,11 @@ jobs:
         IMAGE_NAME: 'ubuntu-16.04'
       macOS:
         IMAGE_NAME: 'macos-10.13'
-      win64:
-        IMAGE_NAME: 'vs2017-win2016'
-        ARCH: 'x64'
+      # Disable win64 build due to electron-updater not working
+      # with updating both 32-bit version and 64-bit version
+      # win64:
+      #   IMAGE_NAME: 'vs2017-win2016'
+      #   ARCH: 'x64'
       win32:
         IMAGE_NAME: 'vs2017-win2016'
         ARCH: 'ia32'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,11 +19,6 @@ jobs:
         IMAGE_NAME: 'ubuntu-16.04'
       macOS:
         IMAGE_NAME: 'macos-10.13'
-      # Disable win64 build due to electron-updater not working
-      # with updating both 32-bit version and 64-bit version
-      # win64:
-      #   IMAGE_NAME: 'vs2017-win2016'
-      #   ARCH: 'x64'
       win32:
         IMAGE_NAME: 'vs2017-win2016'
         ARCH: 'ia32'


### PR DESCRIPTION
This PR is due to disabling x64 build. Add it back if it is needed in the future and the electron-updater issue should be fixed at that moment.