### PR TITLE
Fix minor issues with react-bootstrap 4

### DIFF
--- a/lib/windows/launcher/components/InputLineDialog.jsx
+++ b/lib/windows/launcher/components/InputLineDialog.jsx
@@ -42,6 +42,11 @@ import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 
 class InputLineDialog extends React.Component {
+    constructor(props) {
+        super(props);
+        this.inputNode = React.createRef();
+    }
+
     render() {
         const {
             isVisible,
@@ -63,7 +68,7 @@ class InputLineDialog extends React.Component {
                             <Form.Control
                                 as="input"
                                 type="text"
-                                inputRef={ref => { this.inputNode = ref; }}
+                                ref={this.inputNode}
                                 placeholder={placeholder}
                             />
                         </Form.Group>
@@ -73,7 +78,7 @@ class InputLineDialog extends React.Component {
                             type="submit"
                             variant="primary"
                             className="core-btn"
-                            onClick={() => onOk(this.inputNode.value)}
+                            onClick={() => onOk(this.inputNode.current.value)}
                         >
                             OK
                         </Button>

--- a/lib/windows/launcher/components/SettingsView.jsx
+++ b/lib/windows/launcher/components/SettingsView.jsx
@@ -46,7 +46,7 @@ import ConfirmRemoveSourceDialog from '../containers/ConfirmRemoveSourceDialog';
 
 const CopyToClipboard = ({ text }) => (
     <Button
-        bsSize="small"
+        size="sm"
         variant="light"
         title="Copy to clipboard"
         onClick={() => clipboard.writeText(text)}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "2.8.0-alpha.1",
+    "version": "3.0.0-alpha.1",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",

--- a/resources/css/app.scss
+++ b/resources/css/app.scss
@@ -15,7 +15,7 @@
                 color: white;
                 padding-left: 24px;
             }
-            .dropdown-item:hover {
+            .dropdown-item:hover, .dropdown-item:focus {
                 background-color: $brand-primary-dark;
             }
         }


### PR DESCRIPTION
This PR bumps version to 3.0.0+ since bs4 breaks the old apps. Minor styling issue and broken input line is also addressed.