### PR TITLE
Copy main process env var before loading app

### DIFF
--- a/resources/app.html
+++ b/resources/app.html
@@ -29,6 +29,13 @@
 <div id='app-loader'></div>
 <div id='webapp'></div>
 
+<script>
+    const { NRFJPROG_LIBRARY_PATH } = require('electron').remote.process.env;
+
+    if (NRFJPROG_LIBRARY_PATH) {
+        process.env.NRFJPROG_LIBRARY_PATH = NRFJPROG_LIBRARY_PATH;
+    }
+</script>
 <script src="../dist/app-bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR completes #310 by copying the required environment variable to the app's renderer process before the webpacked app is executed.