### PR TITLE
Ensure running in a writable directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ const windows = require('./main/windows');
 const apps = require('./main/apps');
 const { createMenu } = require('./main/menu');
 
+// Ensure that nRFConnect runs in a directory where it has permission to write
+process.chdir(electronApp.getPath('temp'));
+
 config.init(argv);
 global.homeDir = config.getHomeDir();
 global.userDataDir = config.getUserDataDir();


### PR DESCRIPTION
This fix prevents a crash in nrfjprog when it tries to write its temporary files without correctly setting their paths.