### PR TITLE
Enable dev tools on macOS

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -83,7 +83,7 @@ function createMenu(app) {
                 {
                     label: 'Toggle &Developer Tools',
                     accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-                    visible: false,
+                    visible: true,
                     click: (item, focusedWindow) => {
                         if (focusedWindow) {
                             focusedWindow.toggleDevTools();


### PR DESCRIPTION
This PR is due to enable devtools on mac.