### PR TITLE
Add optional promise to wait for when reopening a device

### DIFF
--- a/lib/windows/app/actions/deviceActions.js
+++ b/lib/windows/app/actions/deviceActions.js
@@ -287,7 +287,7 @@ function getDeviceSetupUserInput(dispatch, message, choices = undefined) {
  * @returns {function(*)} Function that can be passed to redux dispatch.
  */
 export function selectAndSetupDevice(device) {
-    return dispatch => {
+    return async dispatch => {
         dispatch(deviceSelectedAction(device));
 
         const config = getAppConfig();
@@ -309,6 +309,10 @@ export function selectAndSetupDevice(device) {
                 deviceSetup.promiseChoice = (message, choices) => (
                     getDeviceSetupUserInput(dispatch, message, choices)
                 );
+            }
+
+            if (config.releaseCurrentDevice) {
+                await config.releaseCurrentDevice();
             }
 
             setupDevice(device, deviceSetup)


### PR DESCRIPTION
This PR adds support for apps to define _releaseCurrentDevice_ configuration option to ensure safe reopening of the same device.