### PR TITLE
Update log transports to winston 3 API

### DIFF
--- a/lib/api/logging/__tests__/appTransport-test.js
+++ b/lib/api/logging/__tests__/appTransport-test.js
@@ -36,7 +36,14 @@
 
 import AppTransport from '../appTransport';
 
+
 describe('AppTransport', () => {
+    const info = {
+        message: 'Foobar message',
+        level: 'info',
+        timestamp: '2019-07-31T11:00:42.660Z',
+    };
+
     it('should throw error if onLogEntry is not provided to constructor', () => {
         expect(() => new AppTransport({})).toThrow();
     });
@@ -44,54 +51,42 @@ describe('AppTransport', () => {
     it('should include message in log entry', () => {
         const onLogEntry = jest.fn();
         const appTransport = new AppTransport({ onLogEntry });
-        const message = 'Foobar message';
-
-        appTransport.log('info', message, {}, () => {});
+        const { message } = info;
+        appTransport.log(info, () => {});
 
         expect(onLogEntry).toHaveBeenCalledWith(expect.objectContaining({
             message,
         }));
     });
 
-    it('should include meta in log entry', () => {
-        const onLogEntry = jest.fn();
-        const appTransport = new AppTransport({ onLogEntry });
-        const meta = { foo: 'bar' };
-
-        appTransport.log('info', '', meta, () => {});
-
-        expect(onLogEntry).toHaveBeenCalledWith(expect.objectContaining({
-            meta,
-        }));
-    });
-
     it('should include level in log entry', () => {
         const onLogEntry = jest.fn();
         const appTransport = new AppTransport({ onLogEntry });
+        const { level } = info;
 
-        appTransport.log('info', '', {}, () => {});
+        appTransport.log(info, () => {});
 
         expect(onLogEntry).toHaveBeenCalledWith(expect.objectContaining({
-            level: 'info',
+            level,
         }));
     });
 
-    it('should include time in log entry', () => {
+    it('should include timestamp in log entry', () => {
         const onLogEntry = jest.fn();
         const appTransport = new AppTransport({ onLogEntry });
 
-        appTransport.log('info', '', {}, () => {});
+        appTransport.log(info, () => {});
 
-        expect(onLogEntry.mock.calls[0][0].time).toBeInstanceOf(Date);
+        expect(typeof onLogEntry.mock.calls[0][0].timestamp).toBe('string');
     });
 
     it('should increment the log entry id', () => {
         const onLogEntry = jest.fn();
         const appTransport = new AppTransport({ onLogEntry });
 
-        appTransport.log('info', '', {}, () => {});
-        appTransport.log('info', '', {}, () => {});
-        appTransport.log('info', '', {}, () => {});
+        appTransport.log(info, () => {});
+        appTransport.log(info, () => {});
+        appTransport.log(info, () => {});
 
         expect(onLogEntry.mock.calls[0][0].id).toEqual(0);
         expect(onLogEntry.mock.calls[1][0].id).toEqual(1);
@@ -103,7 +98,7 @@ describe('AppTransport', () => {
         const onLogDone = jest.fn();
         const appTransport = new AppTransport({ onLogEntry });
 
-        appTransport.log('info', '', {}, onLogDone);
+        appTransport.log(info, onLogDone);
 
         expect(onLogDone).toHaveBeenCalledWith(null, true);
     });

--- a/lib/api/logging/appTransport.js
+++ b/lib/api/logging/appTransport.js
@@ -48,13 +48,12 @@ export default class AppTransport extends Transport {
         this.entryCount = 0;
     }
 
-    log(level, message, meta, callback) {
+    log({ level, message, timestamp }, callback) {
         this.onLogEntry({
             id: this.entryCount,
-            time: new Date(),
+            timestamp,
             level,
             message,
-            meta,
         });
         this.entryCount += 1;
         callback(null, true);

--- a/lib/api/logging/consoleTransport.js
+++ b/lib/api/logging/consoleTransport.js
@@ -40,7 +40,7 @@ import console from 'console';
 /* eslint-disable class-methods-use-this */
 
 export default class ConsoleTransport extends Transport {
-    log(level, message, { timestamp }, callback) {
+    log({ level, message, timestamp }, callback) {
         console.log(timestamp, level.toUpperCase(), message);
         callback();
     }

--- a/lib/windows/app/components/LogEntry.jsx
+++ b/lib/windows/app/components/LogEntry.jsx
@@ -78,7 +78,7 @@ function hrefReplacer(str) {
 
 const LogEntry = ({ entry }) => {
     const className = `core-log-entry core-log-level-${entry.level}`;
-    const time = moment(entry.time).format('HH:mm:ss.SSS');
+    const time = moment(entry.timestamp).format('HH:mm:ss.SSS');
 
     return (
         <div className={className}>
@@ -91,10 +91,9 @@ const LogEntry = ({ entry }) => {
 LogEntry.propTypes = {
     entry: PropTypes.shape({
         id: PropTypes.number.isRequired,
-        time: PropTypes.instanceOf(Date).isRequired,
+        timestamp: PropTypes.string.isRequired,
         level: PropTypes.string.isRequired,
         message: PropTypes.string.isRequired,
-        meta: PropTypes.object,
     }).isRequired,
 };
 

--- a/lib/windows/app/components/__tests__/LogViewer-test.jsx
+++ b/lib/windows/app/components/__tests__/LogViewer-test.jsx
@@ -55,17 +55,17 @@ describe('LogViewer', () => {
             {
                 id: 1,
                 level: 'info',
-                time: new Date('2017-02-03T12:41:36.020Z'),
+                timestamp: '2017-02-03T12:41:36.020Z',
                 message: 'Info message',
             }, {
                 id: 2,
                 level: 'error',
-                time: new Date('2017-02-03T13:41:36.020Z'),
+                timestamp: '2017-02-03T13:41:36.020Z',
                 message: 'Error message',
             }, {
                 id: 3,
                 level: 'info',
-                time: new Date('2017-02-03T13:41:36.020Z'),
+                timestamp: '2017-02-03T13:41:36.020Z',
                 message: 'For reference see: https://github.com/example/doc.md or reboot Windows.',
             },
         ]);


### PR DESCRIPTION
This PR fixes the warning about legacy log transport implementation by updating the transports to winston API version 3.