### PR TITLE
Download and store release notes

### DIFF
--- a/lib/windows/launcher/actions/appsActions.js
+++ b/lib/windows/launcher/actions/appsActions.js
@@ -64,6 +64,7 @@ export const DOWNLOAD_LATEST_APP_INFO = 'DOWNLOAD_LATEST_APP_INFO';
 export const DOWNLOAD_LATEST_APP_INFO_SUCCESS = 'DOWNLOAD_LATEST_APP_INFO_SUCCESS';
 export const DOWNLOAD_LATEST_APP_INFO_ERROR = 'DOWNLOAD_LATEST_APP_INFO_ERROR';
 export const SET_APP_ICON_PATH = 'SET_APP_ICON_PATH';
+export const SET_APP_RELEASE_NOTE = 'SET_APP_RELEASE_NOTE';
 
 function loadLocalAppsAction() {
     return {
@@ -212,6 +213,15 @@ export function setAppIconPath(source, name, iconPath) {
     };
 }
 
+export function setAppReleaseNoteAction(source, name, releaseNote) {
+    return {
+        type: SET_APP_RELEASE_NOTE,
+        source,
+        name,
+        releaseNote,
+    };
+}
+
 /**
  * Download app icon and dispatch icon update event
  *
@@ -271,10 +281,18 @@ export function loadOfficialApps() {
         mainApps.getOfficialApps()
             .then(apps => {
                 dispatch(loadOfficialAppsSuccess(apps));
-                apps.forEach(({ source, name, url }) => {
+                apps.forEach(app => {
+                    const { source, name, url } = app;
                     const iconPath = `${config.getAppsRootDir(source)}/${name}.svg`;
                     const iconUrl = `${url}.svg`;
                     dispatch(downloadAppIcon(source, name, iconPath, iconUrl));
+                    mainApps.downloadReleaseNotes(app).then(releaseNote => dispatch(
+                        setAppReleaseNoteAction(
+                            source,
+                            name,
+                            releaseNote,
+                        ),
+                    ));
                 });
             })
             .catch(error => {

--- a/lib/windows/launcher/models/index.js
+++ b/lib/windows/launcher/models/index.js
@@ -51,6 +51,7 @@ const ImmutableApp = Record({
     isSupportedEngine: null,
     source: null,
     url: null,
+    releaseNote: null,
 });
 
 function getImmutableApp(app) {
@@ -69,6 +70,7 @@ function getImmutableApp(app) {
         isSupportedEngine: app.isSupportedEngine,
         source: app.source,
         url: app.url,
+        releaseNote: app.releaseNote,
     });
 }
 

--- a/lib/windows/launcher/reducers/__tests__/appsReducer-test.js
+++ b/lib/windows/launcher/reducers/__tests__/appsReducer-test.js
@@ -60,6 +60,7 @@ const app1 = {
     shortcutIconPath: null,
     source: null,
     url: null,
+    releaseNote: null,
 };
 const app2 = {
     name: 'pc-nrfconnect-bar',
@@ -76,6 +77,7 @@ const app2 = {
     shortcutIconPath: null,
     source: null,
     url: null,
+    releaseNote: null,
 };
 
 describe('appsReducer', () => {

--- a/lib/windows/launcher/reducers/appsReducer.js
+++ b/lib/windows/launcher/reducers/appsReducer.js
@@ -92,6 +92,13 @@ function setAppIconPath(state, source, name, iconPath) {
     );
 }
 
+function setAppReleaseNote(state, source, name, releaseNote) {
+    return state.update(
+        state.findKey(x => x.source === source && x.name === name),
+        x => x.merge({ releaseNote }),
+    );
+}
+
 const reducer = (state = initialState, action) => {
     switch (action.type) {
         case AppsActions.LOAD_LOCAL_APPS:
@@ -137,6 +144,9 @@ const reducer = (state = initialState, action) => {
         case AppsActions.SET_APP_ICON_PATH:
             return state.update('officialApps',
                 x => setAppIconPath(x, action.source, action.name, action.iconPath));
+        case AppsActions.SET_APP_RELEASE_NOTE:
+            return state.update('officialApps',
+                x => setAppReleaseNote(x, action.source, action.name, action.releaseNote));
         default:
             return state;
     }

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
         "chmodr": "1.2.0",
         "create-react-class": "15.6.3",
         "electron-log": "3.0.6",
+        "electron-store": "4.0.0",
         "electron-updater": "4.0.14",
         "fs-extra": "8.1.0",
         "mustache": "3.0.1",


### PR DESCRIPTION
This PR adds implementation of downloading release notes from GitHub, which then gets stored by electron-store. The downloaded notes are formatted and assembled to be dispatched and set in application state for further use.