### PR TITLE
Better startup speed and fixed app matching

### DIFF
--- a/lib/windows/launcher/actions/appsActions.js
+++ b/lib/windows/launcher/actions/appsActions.js
@@ -244,25 +244,6 @@ function downloadAppIcon(source, name, iconPath, iconUrl) {
     };
 }
 
-export function downloadLatestAppInfo(options = { rejectIfError: false }) {
-    return dispatch => {
-        dispatch(downloadLatestAppInfoAction());
-
-        return mainApps.downloadAppsJsonFiles()
-            .then(() => mainApps.generateUpdatesJsonFiles())
-            .then(() => dispatch(downloadLatestAppInfoSuccessAction()))
-            .catch(error => {
-                dispatch(downloadLatestAppInfoErrorAction());
-                if (options.rejectIfError) {
-                    throw error;
-                } else {
-                    dispatch(ErrorDialogActions.showDialog('Unable to download '
-                        + `latest app info: ${error.message}`));
-                }
-            });
-    };
-}
-
 export function loadLocalApps() {
     return dispatch => {
         dispatch(loadLocalAppsAction());
@@ -299,6 +280,26 @@ export function loadOfficialApps() {
                 dispatch(loadOfficialAppsError());
                 dispatch(ErrorDialogActions.showDialog('Unable to load apps: '
                     + `${error.message}`));
+            });
+    };
+}
+
+export function downloadLatestAppInfo(options = { rejectIfError: false }) {
+    return dispatch => {
+        dispatch(downloadLatestAppInfoAction());
+
+        return mainApps.downloadAppsJsonFiles()
+            .then(() => mainApps.generateUpdatesJsonFiles())
+            .then(() => dispatch(downloadLatestAppInfoSuccessAction()))
+            .then(() => dispatch(loadOfficialApps()))
+            .catch(error => {
+                dispatch(downloadLatestAppInfoErrorAction());
+                if (options.rejectIfError) {
+                    throw error;
+                } else {
+                    dispatch(ErrorDialogActions.showDialog('Unable to download '
+                        + `latest app info: ${error.message}`));
+                }
             });
     };
 }

--- a/lib/windows/launcher/components/AppManagementView.jsx
+++ b/lib/windows/launcher/components/AppManagementView.jsx
@@ -48,80 +48,47 @@ function getSortedApps(apps) {
     });
 }
 
-class AppManagementView extends React.Component {
-    componentDidMount() {
-        const {
-            onMount,
-            isLatestAppInfoDownloaded,
-            isSkipUpdateApps,
-            onDownloadLatestAppInfo,
-        } = this.props;
-
-        onMount();
-
-        if (!isLatestAppInfoDownloaded && !isSkipUpdateApps) {
-            onDownloadLatestAppInfo();
-        }
-    }
-
-    isProcessing() {
-        const {
-            installingAppName,
-            upgradingAppName,
-            removingAppName,
-        } = this.props;
-        return !!installingAppName || !!upgradingAppName || !!removingAppName;
-    }
-
-    render() {
-        const {
-            apps,
-            installingAppName,
-            upgradingAppName,
-            removingAppName,
-            onInstall,
-            onRemove,
-            onUpgrade,
-            onReadMore,
-            onAppSelected,
-            onCreateShortcut,
-        } = this.props;
-        const isProcessing = this.isProcessing();
-
-        return getSortedApps(apps).map(app => (
-            <AppItem
-                key={`${app.name}-${app.source}`}
-                app={app}
-                isDisabled={isProcessing}
-                isInstalling={installingAppName === app.name}
-                isUpgrading={upgradingAppName === app.name}
-                isRemoving={removingAppName === app.name}
-                onRemove={() => onRemove(app.name, app.source)}
-                onInstall={() => onInstall(app.name, app.source)}
-                onUpgrade={() => onUpgrade(
-                    app.name, app.latestVersion, app.source,
-                )}
-                onReadMore={() => onReadMore(app.homepage)}
-                onAppSelected={() => onAppSelected(app)}
-                onCreateShortcut={() => onCreateShortcut(app)}
-            />
-        ));
-    }
-}
+const AppManagementView = ({
+    apps,
+    installingAppName,
+    upgradingAppName,
+    removingAppName,
+    isProcessing,
+    onInstall,
+    onRemove,
+    onUpgrade,
+    onReadMore,
+    onAppSelected,
+    onCreateShortcut,
+}) => getSortedApps(apps).map(app => (
+    <AppItem
+        key={`${app.name}-${app.source}`}
+        app={app}
+        isDisabled={isProcessing}
+        isInstalling={installingAppName === `${app.source}/${app.name}`}
+        isUpgrading={upgradingAppName === `${app.source}/${app.name}`}
+        isRemoving={removingAppName === `${app.source}/${app.name}`}
+        onRemove={() => onRemove(app.name, app.source)}
+        onInstall={() => onInstall(app.name, app.source)}
+        onUpgrade={() => onUpgrade(
+            app.name, app.latestVersion, app.source,
+        )}
+        onReadMore={() => onReadMore(app.homepage)}
+        onAppSelected={() => onAppSelected(app)}
+        onCreateShortcut={() => onCreateShortcut(app)}
+    />
+));
 
 AppManagementView.propTypes = {
     apps: PropTypes.instanceOf(Iterable).isRequired,
-    isSkipUpdateApps: PropTypes.bool,
-    isLatestAppInfoDownloaded: PropTypes.bool.isRequired,
     installingAppName: PropTypes.string,
     upgradingAppName: PropTypes.string,
     removingAppName: PropTypes.string,
-    onMount: PropTypes.func,
+    isProcessing: PropTypes.bool,
     onInstall: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired,
     onUpgrade: PropTypes.func.isRequired,
     onReadMore: PropTypes.func.isRequired,
-    onDownloadLatestAppInfo: PropTypes.func,
     onAppSelected: PropTypes.func.isRequired,
     onCreateShortcut: PropTypes.func.isRequired,
 };
@@ -130,9 +97,7 @@ AppManagementView.defaultProps = {
     installingAppName: '',
     upgradingAppName: '',
     removingAppName: '',
-    isSkipUpdateApps: false,
-    onMount: () => {},
-    onDownloadLatestAppInfo: () => {},
+    isProcessing: false,
 };
 
 export default AppManagementView;

--- a/lib/windows/launcher/components/__tests__/AppManagementView-test.jsx
+++ b/lib/windows/launcher/components/__tests__/AppManagementView-test.jsx
@@ -59,8 +59,7 @@ describe('AppManagementView', () => {
             <AppManagementView
                 apps={List()}
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                onAppSelected={() => { }}
+                onAppSelected={() => {}}
                 onCreateShortcut={() => {}}
                 onInstall={() => {}}
                 onRemove={() => {}}
@@ -98,14 +97,12 @@ describe('AppManagementView', () => {
                     ])
                 }
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                onAppSelected={() => { }}
+                onAppSelected={() => {}}
                 onCreateShortcut={() => {}}
                 onInstall={() => {}}
                 onRemove={() => {}}
                 onUpgrade={() => {}}
                 onReadMore={() => {}}
-                onMount={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -118,18 +115,18 @@ describe('AppManagementView', () => {
                         name: 'pc-nrfconnect-foo',
                         displayName: 'Foo app',
                         description: 'Foo description',
+                        source: 'bar',
                     }),
                 ])}
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                installingAppName="pc-nrfconnect-foo"
-                onAppSelected={() => { }}
+                installingAppName="bar/pc-nrfconnect-foo"
+                isProcessing
+                onAppSelected={() => {}}
                 onCreateShortcut={() => {}}
                 onInstall={() => {}}
                 onRemove={() => {}}
                 onUpgrade={() => {}}
                 onReadMore={() => {}}
-                onMount={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -144,18 +141,18 @@ describe('AppManagementView', () => {
                         description: 'Foo description',
                         currentVersion: '1.2.3',
                         latestVersion: '1.2.3',
+                        source: 'bar',
                     }),
                 ])}
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                removingAppName="pc-nrfconnect-foo"
-                onAppSelected={() => { }}
+                removingAppName="bar/pc-nrfconnect-foo"
+                isProcessing
+                onAppSelected={() => {}}
                 onCreateShortcut={() => {}}
                 onInstall={() => {}}
                 onRemove={() => {}}
                 onUpgrade={() => {}}
                 onReadMore={() => {}}
-                onMount={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -170,18 +167,18 @@ describe('AppManagementView', () => {
                         description: 'Foo description',
                         currentVersion: '1.2.3',
                         latestVersion: '1.2.4',
+                        source: 'bar',
                     }),
                 ])}
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                upgradingAppName="pc-nrfconnect-foo"
-                onAppSelected={() => { }}
+                upgradingAppName="bar/pc-nrfconnect-foo"
+                isProcessing
+                onAppSelected={() => {}}
                 onCreateShortcut={() => {}}
                 onInstall={() => {}}
                 onRemove={() => {}}
                 onUpgrade={() => {}}
                 onReadMore={() => {}}
-                onMount={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -199,14 +196,12 @@ describe('AppManagementView', () => {
             <AppManagementView
                 apps={List([app])}
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                onAppSelected={() => { }}
+                onAppSelected={() => {}}
                 onCreateShortcut={() => {}}
                 onInstall={onInstall}
                 onRemove={() => {}}
                 onUpgrade={() => {}}
                 onReadMore={() => {}}
-                onMount={() => {}}
             />,
         );
         wrapper.find('button[title="Install Foobar displayName"]').first().simulate('click');
@@ -228,14 +223,12 @@ describe('AppManagementView', () => {
             <AppManagementView
                 apps={List([app])}
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                onAppSelected={() => { }}
+                onAppSelected={() => {}}
                 onCreateShortcut={() => {}}
                 onInstall={() => {}}
                 onRemove={onRemove}
                 onUpgrade={() => {}}
                 onReadMore={() => {}}
-                onMount={() => {}}
             />,
         );
 
@@ -260,61 +253,17 @@ describe('AppManagementView', () => {
             <AppManagementView
                 apps={List([app])}
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                onAppSelected={() => { }}
+                onAppSelected={() => {}}
                 onCreateShortcut={() => {}}
                 onInstall={() => {}}
                 onRemove={() => {}}
                 onUpgrade={onUpgrade}
                 onReadMore={() => {}}
-                onMount={() => {}}
             />,
         );
         wrapper.find('button[title="Update Foobar displayName"]').first().simulate('click');
 
         expect(onUpgrade).toHaveBeenCalledWith(app.name, app.latestVersion, app.source);
-    });
-
-    it('should invoke onDownloadLatestAppInfo when mounted and latest app info is not downloaded', () => {
-        const onDownloadLatestAppInfo = jest.fn();
-        mount(
-            <AppManagementView
-                apps={List([])}
-                isRetrievingApps={false}
-                isLatestAppInfoDownloaded={false}
-                onAppSelected={() => { }}
-                onCreateShortcut={() => {}}
-                onDownloadLatestAppInfo={onDownloadLatestAppInfo}
-                onInstall={() => {}}
-                onRemove={() => {}}
-                onUpgrade={() => {}}
-                onReadMore={() => {}}
-                onMount={() => {}}
-            />,
-        );
-
-        expect(onDownloadLatestAppInfo).toHaveBeenCalled();
-    });
-
-    it('should not invoke onDownloadLatestAppInfo when mounted and latest app info has been downloaded', () => {
-        const onDownloadLatestAppInfo = jest.fn();
-        mount(
-            <AppManagementView
-                apps={List([])}
-                isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                onDownloadLatestAppInfo={onDownloadLatestAppInfo}
-                onAppSelected={() => { }}
-                onCreateShortcut={() => {}}
-                onInstall={() => {}}
-                onRemove={() => {}}
-                onUpgrade={() => {}}
-                onReadMore={() => {}}
-                onMount={() => {}}
-            />,
-        );
-
-        expect(onDownloadLatestAppInfo).not.toHaveBeenCalled();
     });
 
     it('should render more info links for correctly defined homepage', () => {
@@ -342,14 +291,12 @@ describe('AppManagementView', () => {
                     ])
                 }
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
-                onAppSelected={() => { }}
+                onAppSelected={() => {}}
                 onCreateShortcut={() => {}}
                 onInstall={() => {}}
                 onRemove={() => {}}
                 onUpgrade={() => {}}
                 onReadMore={() => {}}
-                onMount={() => {}}
             />,
         )).toMatchSnapshot();
     });
@@ -368,14 +315,12 @@ describe('AppManagementView', () => {
             <AppManagementView
                 apps={List([app])}
                 isRetrievingApps={false}
-                isLatestAppInfoDownloaded
                 onAppSelected={onAppSelected}
                 onCreateShortcut={() => {}}
                 onInstall={() => {}}
                 onRemove={() => {}}
                 onUpgrade={() => {}}
                 onReadMore={() => {}}
-                onMount={() => {}}
             />,
         );
         wrapper.find('button[title="Open Foobar displayName"]').first().simulate('click');

--- a/lib/windows/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
+++ b/lib/windows/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
@@ -46,7 +46,7 @@ exports[`AppManagementView should disable buttons and display "Installing..." bu
       <div
         className="small text-muted-more"
       >
-        local
+        bar
       </div>
     </div>
     <div
@@ -141,7 +141,7 @@ exports[`AppManagementView should disable buttons and display "Removing..." butt
       <div
         className="small text-muted-more"
       >
-        local
+        bar
         , v
         1.2.3
       </div>
@@ -238,7 +238,7 @@ exports[`AppManagementView should disable buttons and display "Upgrading..." but
       <div
         className="small text-muted-more"
       >
-        local
+        bar
         , v
         1.2.3
          (v

--- a/lib/windows/launcher/containers/AppManagementContainer.js
+++ b/lib/windows/launcher/containers/AppManagementContainer.js
@@ -35,24 +35,25 @@
  */
 
 import { connect } from 'react-redux';
-import { remote } from 'electron';
 import AppManagementView from '../components/AppManagementView';
 import * as AppsActions from '../actions/appsActions';
 import { openUrlInDefaultBrowser } from '../../../util/fileUtil';
 import * as DesktopShortcutActions from '../actions/desktopShortcutActions';
 
-const config = remote.require('./main/config');
-
 function mapStateToProps(state) {
-    const { apps } = state;
+    const {
+        apps: {
+            localApps, officialApps,
+            installingAppName, removingAppName, upgradingAppName,
+        },
+    } = state;
 
     return {
-        apps: apps.localApps.concat(apps.officialApps),
-        isLatestAppInfoDownloaded: apps.isLatestAppInfoDownloaded,
-        isSkipUpdateApps: config.isSkipUpdateApps(),
-        installingAppName: apps.installingAppName,
-        removingAppName: apps.removingAppName,
-        upgradingAppName: apps.upgradingAppName,
+        apps: localApps.concat(officialApps),
+        installingAppName,
+        removingAppName,
+        upgradingAppName,
+        isProcessing: !!installingAppName || !!upgradingAppName || !!removingAppName,
     };
 }
 
@@ -66,7 +67,6 @@ function mapDispatchToProps(dispatch) {
             AppsActions.upgradeOfficialApp(name, version, source),
         ),
         onReadMore: homepage => openUrlInDefaultBrowser(homepage),
-        onDownloadLatestAppInfo: () => dispatch(AppsActions.downloadLatestAppInfo()),
         // Launcher actions
         onAppSelected: app => dispatch(AppsActions.checkEngineAndLaunch(app)),
         onCreateShortcut: app => dispatch(DesktopShortcutActions.createShortcut(app)),

--- a/lib/windows/launcher/index.js
+++ b/lib/windows/launcher/index.js
@@ -80,11 +80,9 @@ net.registerProxyLoginHandler((authInfo, callback) => {
         });
 });
 
-render(rootElement, document.getElementById('webapp'), () => {
-    downloadLatestAppInfo()
-        .then(() => {
-            checkForCoreUpdates();
-            store.dispatch(AppsActions.loadLocalApps());
-            store.dispatch(AppsActions.loadOfficialApps());
-        });
+render(rootElement, document.getElementById('webapp'), async () => {
+    await store.dispatch(AppsActions.loadLocalApps());
+    await store.dispatch(AppsActions.loadOfficialApps());
+    await downloadLatestAppInfo();
+    await checkForCoreUpdates();
 });

--- a/lib/windows/launcher/reducers/__tests__/appsReducer-test.js
+++ b/lib/windows/launcher/reducers/__tests__/appsReducer-test.js
@@ -161,8 +161,9 @@ describe('appsReducer', () => {
         const state = reducer(initialState, {
             type: AppsActions.INSTALL_OFFICIAL_APP,
             name: 'pc-nrfconnect-foo',
+            source: 'bar',
         });
-        expect(state.installingAppName).toEqual('pc-nrfconnect-foo');
+        expect(state.installingAppName).toEqual('bar/pc-nrfconnect-foo');
     });
 
     it('should not be installing app after INSTALL_OFFICIAL_APP_SUCCESS has been dispatched', () => {
@@ -186,8 +187,9 @@ describe('appsReducer', () => {
         const state = reducer(initialState, {
             type: AppsActions.REMOVE_OFFICIAL_APP,
             name: 'pc-nrfconnect-foo',
+            source: 'bar',
         });
-        expect(state.removingAppName).toEqual('pc-nrfconnect-foo');
+        expect(state.removingAppName).toEqual('bar/pc-nrfconnect-foo');
     });
 
     it('should not be removing app after REMOVE_OFFICIAL_APP_SUCCESS has been dispatched', () => {
@@ -211,8 +213,9 @@ describe('appsReducer', () => {
         const state = reducer(initialState, {
             type: AppsActions.UPGRADE_OFFICIAL_APP,
             name: 'pc-nrfconnect-foo',
+            source: 'bar',
         });
-        expect(state.upgradingAppName).toEqual('pc-nrfconnect-foo');
+        expect(state.upgradingAppName).toEqual('bar/pc-nrfconnect-foo');
     });
 
     it('should not be upgrading app after UPGRADE_OFFICIAL_APP_SUCCESS has been dispatched', () => {

--- a/lib/windows/launcher/reducers/appsReducer.js
+++ b/lib/windows/launcher/reducers/appsReducer.js
@@ -114,11 +114,11 @@ const reducer = (state = initialState, action) => {
         case AppsActions.LOAD_OFFICIAL_APPS_ERROR:
             return state.set('isLoadingOfficialApps', false);
         case AppsActions.INSTALL_OFFICIAL_APP:
-            return state.set('installingAppName', action.name);
+            return state.set('installingAppName', `${action.source}/${action.name}`);
         case AppsActions.REMOVE_OFFICIAL_APP:
-            return state.set('removingAppName', action.name);
+            return state.set('removingAppName', `${action.source}/${action.name}`);
         case AppsActions.UPGRADE_OFFICIAL_APP:
-            return state.set('upgradingAppName', action.name);
+            return state.set('upgradingAppName', `${action.source}/${action.name}`);
         case AppsActions.INSTALL_OFFICIAL_APP_SUCCESS:
             return state.set('installingAppName', initialState.installingAppName);
         case AppsActions.REMOVE_OFFICIAL_APP_SUCCESS:


### PR DESCRIPTION
This PR fixes multiple requests to the same apps.json during startup and also renders the launcher as soon as local and installed apps are parsed, doesn't wait for the network.
AppManagementView is also cleaned up, unused methods are removed and tests/snapshots updated.