### PR TITLE
Revert token based GH api calls and use etag match

### DIFF
--- a/main/registryApi.js
+++ b/main/registryApi.js
@@ -59,7 +59,8 @@ function getLatestFromPackageInfo(packageInfo) {
 }
 
 function getPackageInfo(name, regUrl) {
-    return net.downloadToJson(getPackageUrl(name, regUrl));
+    return net.downloadToJson(getPackageUrl(name, regUrl))
+        .then(([packageInfo]) => packageInfo);
 }
 
 /**


### PR DESCRIPTION
In this PR the token based authentication fallback is reverted.
The solution to save github rate limit is to use conditional requests where the ETag header is used to check for updated content.
For this net.downloadTo... functions resolve with an array of [responseData, responseHeaders], so the responseHeader can be used when downloading the release notes.