### PR TITLE
Move Trace Collector to NordicSemiconductor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ When starting nRF Connect for Desktop a central launcher is shown. It enables yo
 * [RSSI Viewer](https://github.com/NordicSemiconductor/pc-nrfconnect-rssi)
 * [LTE Link Monitor](https://github.com/NordicSemiconductor/pc-nrfconnect-linkmonitor)
 * [Getting Started Assistant](https://github.com/NordicSemiconductor/pc-nrfconnect-gettingstarted)
-* Trace Collector
+* [Trace Collector](https://github.com/NordicSemiconductor/pc-nrfconnect-tracecollector)
 
 [Further documentation on some apps is provided in the Nordic Semiconductor Infocenter](https://infocenter.nordicsemi.com/topic/struct_nrftools/struct/nrftools_nrfconnect.html).
 

--- a/apps.json
+++ b/apps.json
@@ -32,6 +32,7 @@
     "pc-nrfconnect-tracecollector": {
         "displayName": "Trace Collector",
         "description": "Capture nRF91 modem trace",
+        "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-tracecollector",
         "url": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/pc-nrfconnect-tracecollector"
     },
     "pc-nrfconnect-gettingstarted": {


### PR DESCRIPTION
This PR is due to moving trace collector from Playground to NordicsemiConductor