### PR TITLE
Better dev tools

### DIFF
--- a/azure-pipelines-internal.yml
+++ b/azure-pipelines-internal.yml
@@ -1,5 +1,5 @@
 trigger:
-- release/internal/*
+- internal/release/*
 
 jobs:
 - job: Build

--- a/index.js
+++ b/index.js
@@ -58,9 +58,12 @@ if (basename(execPath, '.exe') !== 'electron') {
 }
 
 const {
-    Menu, ipcMain, dialog, app: electronApp,
+    Menu, ipcMain, dialog, app: electronApp, BrowserWindow,
 } = require('electron');
 const { argv } = require('yargs');
+const {
+    default: installExtension, REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS,
+} = require('electron-devtools-installer');
 
 const config = require('./main/config');
 const windows = require('./main/windows');
@@ -78,6 +81,16 @@ global.appsRootDir = config.getAppsRootDir();
 const applicationMenu = Menu.buildFromTemplate(createMenu(electronApp));
 
 electronApp.on('ready', () => {
+    if (process.argv.includes('--install-dev-tools')) {
+        installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS])
+            .then(names => console.log(`Added Extensions:  ${names}`))
+            .catch(err => console.log(`An error occurred: ${err}`));
+    }
+    if (process.argv.includes('--remove-dev-tools')) {
+        const devToolsExtensions = Object.keys(BrowserWindow.getDevToolsExtensions());
+        devToolsExtensions.forEach(BrowserWindow.removeDevToolsExtension);
+    }
+
     Menu.setApplicationMenu(applicationMenu);
     apps.initAppsDirectory()
         .then(() => {

--- a/index.js
+++ b/index.js
@@ -58,17 +58,15 @@ if (basename(execPath, '.exe') !== 'electron') {
 }
 
 const {
-    Menu, ipcMain, dialog, app: electronApp, BrowserWindow,
+    Menu, ipcMain, dialog, app: electronApp,
 } = require('electron');
 const { argv } = require('yargs');
-const {
-    default: installExtension, REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS,
-} = require('electron-devtools-installer');
 
 const config = require('./main/config');
 const windows = require('./main/windows');
 const apps = require('./main/apps');
 const { createMenu } = require('./main/menu');
+const handleDevtoolsRequest = require('./main/devtools');
 
 // Ensure that nRFConnect runs in a directory where it has permission to write
 process.chdir(electronApp.getPath('temp'));
@@ -81,15 +79,7 @@ global.appsRootDir = config.getAppsRootDir();
 const applicationMenu = Menu.buildFromTemplate(createMenu(electronApp));
 
 electronApp.on('ready', () => {
-    if (process.argv.includes('--install-dev-tools')) {
-        installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS])
-            .then(names => console.log(`Added Extensions:  ${names}`))
-            .catch(err => console.log(`An error occurred: ${err}`));
-    }
-    if (process.argv.includes('--remove-dev-tools')) {
-        const devToolsExtensions = Object.keys(BrowserWindow.getDevToolsExtensions());
-        devToolsExtensions.forEach(BrowserWindow.removeDevToolsExtension);
-    }
+    handleDevtoolsRequest();
 
     Menu.setApplicationMenu(applicationMenu);
     apps.initAppsDirectory()

--- a/lib/store/configureStore.js
+++ b/lib/store/configureStore.js
@@ -38,18 +38,17 @@ import { createStore, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import thunk from 'redux-thunk';
 
-function createMiddleware(app) {
+function createMiddleware(appMiddleware) {
     const middlewares = [thunk];
 
-    const { middleware } = app || {};
-    if (middleware) {
-        middlewares.push(middleware);
+    if (appMiddleware) {
+        middlewares.push(appMiddleware);
     }
 
     return composeWithDevTools(applyMiddleware(...middlewares));
 }
 
-export default (rootReducer, app) => createStore(
+export default (rootReducer, app = {}) => createStore(
     rootReducer,
-    createMiddleware(app),
+    createMiddleware(app.middleware),
 );

--- a/lib/store/configureStore.js
+++ b/lib/store/configureStore.js
@@ -36,38 +36,14 @@
 
 import { createStore, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
-import { createLogger } from 'redux-logger';
-import Immutable from 'immutable';
 import thunk from 'redux-thunk';
 
-function createReduxLogger() {
-    return createLogger({
-        collapsed: true,
-        stateTransformer: state => {
-            const newState = {};
-            Object.keys(state).forEach(key => {
-                if (Immutable.Iterable.isIterable(state[key])) {
-                    newState[key] = state[key].toJS();
-                } else {
-                    newState[key] = state[key];
-                }
-            });
-            return newState;
-        },
-    });
-}
-
 function createMiddleware(app) {
-    const isProduction = process.env.NODE_ENV === 'production';
     const middlewares = [thunk];
 
     const { middleware } = app || {};
     if (middleware) {
         middlewares.push(middleware);
-    }
-
-    if (!isProduction) {
-        middlewares.push(createReduxLogger());
     }
 
     return composeWithDevTools(applyMiddleware(...middlewares));

--- a/lib/store/configureStore.js
+++ b/lib/store/configureStore.js
@@ -35,6 +35,7 @@
  */
 
 import { createStore, applyMiddleware } from 'redux';
+import { composeWithDevTools } from 'redux-devtools-extension';
 import { createLogger } from 'redux-logger';
 import Immutable from 'immutable';
 import thunk from 'redux-thunk';
@@ -69,7 +70,7 @@ function createMiddleware(app) {
         middlewares.push(createReduxLogger());
     }
 
-    return applyMiddleware(...middlewares);
+    return composeWithDevTools(applyMiddleware(...middlewares));
 }
 
 export default (rootReducer, app) => createStore(

--- a/main/devtools.js
+++ b/main/devtools.js
@@ -1,0 +1,76 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+const { app, BrowserWindow } = require('electron');
+const {
+    default: downloadAndInstall,
+    REACT_DEVELOPER_TOOLS,
+    REDUX_DEVTOOLS,
+} = require('electron-devtools-installer');
+
+const installDevtools = async () => {
+    try {
+        const forceReinstall = true;
+        const devToolsExtensions = [REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS];
+        const names = await downloadAndInstall(devToolsExtensions, forceReinstall);
+        console.log('Added devtool extensions:', names);
+        app.quit();
+    } catch (err) {
+        console.log('An error occurred while adding the devtools: ', err);
+    }
+};
+
+const removeDevtools = () => {
+    const devToolsExtensions = Object.keys(
+        BrowserWindow.getDevToolsExtensions(),
+    );
+    console.log('Removing devtool extensions:', devToolsExtensions);
+
+    devToolsExtensions.forEach(BrowserWindow.removeDevToolsExtension);
+
+    // Sometimes if we quit too fast we get a crash message here, so let us just wait a moment.
+    setTimeout(app.quit, 1000);
+};
+
+module.exports = () => {
+    if (process.argv.includes('--install-devtools')) {
+        installDevtools();
+    }
+
+    if (process.argv.includes('--remove-devtools')) {
+        removeDevtools();
+    }
+};

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
         "prettysize": "2.0.0",
         "react-infinite": "github:NordicSemiconductor/react-infinite#react-15.5",
         "redux-devtools-extension": "^2.13.8",
-        "redux-logger": "3.0.6",
         "redux-thunk": "2.3.0",
         "spectron": "7.0.0",
         "tar": "4.4.10",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
         "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\"",
         "get-jlink": "get-jlink -o build",
         "pack": "npm run build && build -p never",
-        "release": "build -p always"
+        "release": "build -p always",
+        "install-devtools": "electron . --install-devtools",
+        "remove-devtools": "electron . --remove-devtools"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "Proprietary",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
         "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#v3.1.0",
         "prettysize": "2.0.0",
         "react-infinite": "github:NordicSemiconductor/react-infinite#react-15.5",
+        "redux-devtools-extension": "^2.13.8",
         "redux-logger": "3.0.6",
         "redux-thunk": "2.3.0",
         "spectron": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
         "bootstrap": "4.3.1",
         "electron": "5.0.6",
         "electron-builder": "20.44.4",
+        "electron-devtools-installer": "^2.2.4",
         "electron-is-dev": "1.1.0",
         "mini-css-extract-plugin": "0.8.0",
         "moment": "2.24.0",


### PR DESCRIPTION
This enables the use of the Redux DevTools and eases installing (and removing) the DevTools for Redux and React, which is also described in NordicSemiconductor/pc-nrfconnect-docs#4.

With the Redux DevTools the Redux logger is not needed anymore, so it is removed.