### PR TITLE
Changelog as release notes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,175 @@
+## Version 3.3.0
+### Features
+- Added support for nRF53 series, nRF52833, and MCUboot DFU
+- Updated to pc-nrfjprog-js v1.6.0, including bundled nrfjprog v10.5.0 and JLink 6.54c #385
+- Updated icon colors #373
+### Bug fixes
+- Fixed bug where app was opened in unreachable location #383
+
+## Version 3.2.0
+### Features
+- Launcher has a new look #326
+- Logo and brand color updated  #352
+- Installation and launch of apps are now unified on the same page #326
+- Added ability to show release notes for apps in launcher #351
+- Release notes are shown before updating #351
+- Faster startup #350
+- Apps get a read more link when the source provides a homepage URL #344
+### Bug fixes
+- Desktop shortcuts for apps from sources with names with white space are now generated correctly #358
+- Text in log views is now selectable again #343
+
+## Version 3.1.0
+### Updates
+- Updated to pc-ble-driver-js v2.6.1 with electron 5 support #324
+- Updated to pc-nrfjprog-js v1.5.8, including bundled nrfjprog v10.3.0 and electron 5 support #324
+- Updated log transports to winston 3 API #327
+### Bug fixes
+- Fixed shortcut generation on macOS #331 #332 #333  #334
+- Fixed libusb errors and multiple event handlers #337
+- Fixed winston multiple arguments #325
+- Fixed multiple postinstall #325
+- Fixed main layout scroll #340
+
+## Version 3.0.0
+### Updates
+- Updated to React Bootstrap 4 #306
+React Bootstrap is a fundamental dependency for nRF Connect for Desktop, used for UI components and layout. The update is a breaking change, requiring all apps to be updated.
+There are no changes to nRF Connect features, except for some minor visual differences.
+- Updated to pc-nrfjprog-js v1.5.4, including bundled nrfjprog v10.2.1 #319
+### Bug fixes
+- Fixed auto update issue #317
+- Fixed nrfjprog library path issue for pc-nrfjprog-js #310 #311 #312
+- Fixed shortcut generation on macOS #314
+
+## Version 2.7.0
+### New features
+- Added support for pc-nrfjprog-js v1.5.1, including nrfjprog v10.1.1 with DFU programming #295 #296  #301
+- Added system report generation #289
+- Bundled nrfjprog libraries on Windows #296
+- Added copy-to-clipboard to source URL and make it selectable #291
+### Bug fixes
+- Fixed proxy handling by ensuring sequential requests #302
+- Fixed multiple loading of libusb issue #288
+
+## Version 2.6.2
+### Bugfix
+- Updated pc-nrfjprog-js to version 1.4.4 that fixes logging related crash experienced with PPK app
+- Updated related prebuilt modules
+
+## Version 2.6.1
+### Bugfix
+- Fixed multiple source updating issue  #272
+
+## Version 2.6.0
+### Features
+- Added new way of distributing apps such as official, internal, etc, by introducing support for multiple app sources #256 #259
+- Provided all precompiled​ dependencies. #263 #266  #267
+- Updated pc-nrfjprog-js to version 1.4.1 along with nrfjprog v9.8.1 #263
+- Updated info about bug reporting and added issue template file #265 #268
+- Updated product page link URLs  #255
+- Updated electron to 2.0.11 #261
+- Supported displaying multiple serialports and board version of a device #262
+- Removed 'Debug probe' item in device selector #264
+### Bugfix
+- Fixed links in LogViewer to open urls in browser #258
+
+## Version 2.5.0
+### Features
+- Updated pc-ble-driver-js to 2.4.2 #254
+    See changes for v2.4.2 https://github.com/NordicSemiconductor/pc-ble-driver-js/releases
+- Updated electron to 2.0 #252
+- Updated jest to 23.4.1 #248 #249 #250
+- Updated nrf-device-setup-js to 0.3.0 to support bootloader update #247
+- Supported link in log messages #245
+- Supported to relaunch app when encountering libusb error #242
+- Exposed start & stop watching device API #244  #246
+### Bugfix
+- Fixed tests for breaking issue of jsdom #251
+
+## Version 2.4.0
+### Features
+- Added support for nRF52840 dongle #204, #219, #220
+- Updated pc-ble-driver-js to 2.4.1 #214
+    See changes for v2.4.0 and v2.4.1 https://github.com/NordicSemiconductor/pc-ble-driver-js/releases
+- Support for generic (jprog/dfu) device setup by nrf-device-setup module
+- Upgraded to Electron v1.8 #203
+- API documentation of using the new DeviceSelector and device setup configuration
+- Troubleshooting documentation related to USB issues #208, #212, #223
+
+## Version 2.3.2
+### Bugfixes
+- Use developer.nordicsemi.com as registry for apps (0c6a405)
+
+## Version 2.3.1
+### Bugfixes
+- Fix issue with apps failing to install (#206)
+
+## Version 2.3.0-alpha.6
+Pre-release with Linux AppImage.
+
+## Version 2.3.0
+### Features
+- Added AppImage release artifact for Linux with support for automatic updates (#156)
+- Added the [usb module](https://www.npmjs.com/package/usb) from npm, so that apps can import it (#157)
+- New opt-in device selector with support for libusb devices (experimental) (#157)
+- Added logging of meta information when loading apps (#154)
+- Showing link to release notes in auto update dialog (#148, #163)
+- Allowing user to overwrite old app when adding a new local app that already exists (#143)
+- Using separate log and data directories for apps (#139)
+- Upgraded to pc-nrfjprog-js v1.2.0 (https://github.com/NordicSemiconductor/pc-nrfjprog-js/releases/tag/v1.2.0)
+- Upgraded to pc-ble-driver-js v2.3.0 (https://github.com/NordicSemiconductor/pc-ble-driver-js/releases/tag/v2.3.0)
+### Bugfixes
+- Improved icon resolution for app shortcuts (#152)
+- Improved icon resolution on macOS (#147)
+- Improved handling of edge cases in J-Link serial number lookup (#145, #146)
+- Fixed issue with side panel not visible on narrow screens (#141)
+- Verifying that serial port is not dead when selected (#137)
+
+## Version 2.3.0-alpha.3
+Pre-release which improves serial number lookup on Windows (#146).
+
+## Version 2.3.0-alpha.2
+Pre-release with handling of edge cases in J-Link serial number lookup (#145).
+
+## Version 2.2.1
+### Bugfixes
+- Improve JLink serial number lookup time on Windows (#135)
+- pc-ble-driver-js: Increase retransmission interval to give the peer more time to repond (https://github.com/NordicSemiconductor/pc-ble-driver-js/pull/99)
+- pc-ble-driver-js: Emit debug message instead of error for unsupported devkits (https://github.com/NordicSemiconductor/pc-ble-driver-js/pull/95)
+
+## Version 2.2.0
+### Features
+- Allow creating desktop shortcuts for installed apps (#118, #120, #124)
+- Upgrade to pc-nrfjprog-js v1.1.0 and nRF5x-Command-Line-Tools v9.7.1 (#134)
+- Upgrade to pc-ble-driver-js v2.1.0 (https://github.com/NordicSemiconductor/pc-ble-driver-js/releases/tag/v2.1.0)
+### Bugfixes
+- Fix issue with JLink library not found when installed in custom location on Linux/macOS (fixed by command line tools v9.7.1)
+
+## Version 2.1.0
+### Features
+- Improved support for proxy servers (#104, #107, #113)
+- New settings screen that allows turning off checking for updates at startup (#104)
+- Make it easier for users to install apps manually (#105, #111)
+- Allow apps to filter ports in the serial port selector (#106)
+### Fixes
+- Disable navigation when items are dragged and dropped into the application (#110)
+### Installation
+Downloads are available for Windows (exe), macOS (dmg), and Linux (tar.gz).
+
+## Version 2.1.0-alpha.0
+Pre-release with improved support for proxies, ref. #104.
+
+## Version 2.0.0
+While nRF Connect v1 was a dedicated Bluetooth low energy tool, v2 is a framework that can launch multiple desktop apps. The Bluetooth low energy tool has been [rewritten as an app](https://github.com/NordicSemiconductor/pc-nrfconnect-ble) for the nRF Connect framework, and can be installed and launched through the nRF Connect UI.
+### Main features
+- Allows users to easily install, update, and launch apps
+- Allows developers to [create new apps](https://github.com/NordicSemiconductor/pc-nrfconnect-core#creating-apps)
+- Supports Windows, macOS, and Linux
+- Automatic updates for Windows and macOS
+### Installation
+Downloads are available for Windows (exe), macOS (dmg), and Linux (tar.gz).
+
+## Version 2.0.0-alpha.15
+Alpha release for testing.
+

--- a/main/net.js
+++ b/main/net.js
@@ -68,19 +68,26 @@ function downloadToBuffer(url, headers = {}) {
         Object.keys(headers).forEach(key => request.setHeader(key, headers[key]));
 
         request.on('response', response => {
-            if (response.statusCode >= 400) {
-                const error = new Error(`Unable to download ${url}. Got status code `
-                    + `${response.statusCode}`);
-                error.statusCode = response.statusCode;
+            const { statusCode } = response;
+            if (statusCode >= 400) {
+                const error = new Error(`Unable to download ${url}. Got status code ${statusCode}`);
+                error.statusCode = statusCode;
                 reject(error);
                 return;
             }
+            const etag = Array.isArray(response.headers.etag)
+                ? response.headers.etag[0] : undefined;
+
             const buffer = [];
             const addToBuffer = data => {
                 buffer.push(data);
             };
             response.on('data', data => addToBuffer(data));
-            response.on('end', () => resolve(Buffer.concat(buffer)));
+            response.on('end', () => resolve({
+                buffer: Buffer.concat(buffer),
+                etag,
+                statusCode,
+            }));
             response.on('error', error => reject(new Error(`Error when reading ${url}: `
                 + `${error.message}`)));
         });
@@ -102,7 +109,7 @@ function downloadToBuffer(url, headers = {}) {
  */
 function downloadToString(url, headers) {
     return downloadToBuffer(url, headers)
-        .then(buffer => buffer.toString());
+        .then(({ buffer }) => buffer.toString());
 }
 
 /**
@@ -129,8 +136,8 @@ function downloadToJson(url, headers) {
 function downloadToFile(url, filePath) {
     return new Promise((resolve, reject) => {
         downloadToBuffer(url)
-            .then(data => {
-                fs.writeFile(filePath, data, err => {
+            .then(({ buffer }) => {
+                fs.writeFile(filePath, buffer, err => {
                     if (err) {
                         reject(err);
                     } else {

--- a/main/net.js
+++ b/main/net.js
@@ -68,7 +68,7 @@ function downloadToBuffer(url, headers) {
         Object.keys(headers || {}).forEach(key => request.setHeader(key, headers[key]));
 
         request.on('response', response => {
-            if (response.statusCode !== 200) {
+            if (response.statusCode >= 400) {
                 const error = new Error(`Unable to download ${url}. Got status code `
                     + `${response.statusCode}`);
                 error.statusCode = response.statusCode;

--- a/main/net.js
+++ b/main/net.js
@@ -104,11 +104,10 @@ function downloadToBuffer(url, headers = {}) {
  * which reads proxy settings from the system.
  *
  * @param {string} url the URL to download.
- * @param {object} headers optional object passed to request headers.
  * @returns {Promise} promise that resolves when the data has been downloaded.
  */
-function downloadToString(url, headers) {
-    return downloadToBuffer(url, headers)
+function downloadToString(url) {
+    return downloadToBuffer(url)
         .then(({ buffer }) => buffer.toString());
 }
 
@@ -138,11 +137,10 @@ function downloadToStringIfChanged(url, previousEtag) {
  * which reads proxy settings from the system.
  *
  * @param {string} url the URL to download.
- * @param {object} headers optional object passed to request headers.
  * @returns {Promise} promise that resolves when the data has been downloaded.
  */
-function downloadToJson(url, headers) {
-    return downloadToString(url, headers)
+function downloadToJson(url) {
+    return downloadToString(url)
         .then(string => JSON.parse(string));
 }
 

--- a/main/net.js
+++ b/main/net.js
@@ -58,14 +58,14 @@ function registerProxyLoginHandler(onLoginRequested) {
     onProxyLogin = onLoginRequested;
 }
 
-function downloadToBuffer(url, headers) {
+function downloadToBuffer(url, headers = {}) {
     return new Promise((resolve, reject) => {
         const request = net.request({
             url,
             session: session.fromPartition(NET_SESSION_NAME),
         });
         request.setHeader('pragma', 'no-cache');
-        Object.keys(headers || {}).forEach(key => request.setHeader(key, headers[key]));
+        Object.keys(headers).forEach(key => request.setHeader(key, headers[key]));
 
         request.on('response', response => {
             if (response.statusCode >= 400) {


### PR DESCRIPTION
This is part of [NCP-2820](https://projecttools.nordicsemi.no/jira/browse/NCP-2820). The whole concept is described there.

With this change the release notes are not fetched from GitHub anymore, instead they are retrieved from developer.nordicsemi.com. E.g. the release notes for the BLE app will be retrieved from http://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/pc-nrfconnect-ble-Changelog.md.

To make the launch faster and spare users with a slow connection some bandwidth, the launcher uses [ETags](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag), to retrieve the changelog only if it has changed.

I already uploaded changelogs manually for each app to developer.nordicsemi.com, so they are already there. This is useful for testing now and also that we are able to use the new functionality even before the apps are published again.

Even though it is not needed, this also adds a `Changelog.md` for this project, to make it consistent with the app projects.

There will be separate PRs for [pc-nrfconnect-devdep](https://github.com/NordicSemiconductor/pc-nrfconnect-devdep), teaching it how to upload the `Changelog.md` of an app when publishing it and for each app to add an `Changelog.md` and utilise the new version of devdep. 