### PR TITLE
Fix: Launcher could not start in production

### DIFF
--- a/src/main/devtools.js
+++ b/src/main/devtools.js
@@ -35,16 +35,20 @@
  */
 
 const { app, BrowserWindow } = require('electron');
-const {
-    default: downloadAndInstall,
-    REACT_DEVELOPER_TOOLS,
-    REDUX_DEVTOOLS,
-} = require('electron-devtools-installer');
+
+let devToolsInstaller;
+try {
+    devToolsInstaller = require('electron-devtools-installer');
+} catch {
+    // Ignore missing devtools dependency here, check later for it when needed
+}
 
 const installDevtools = async () => {
     try {
+        const downloadAndInstall = devToolsInstaller.default;
+        const devToolsExtensions = [devToolsInstaller.REACT_DEVELOPER_TOOLS, devToolsInstaller.REDUX_DEVTOOLS];
         const forceReinstall = true;
-        const devToolsExtensions = [REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS];
+
         const names = await downloadAndInstall(devToolsExtensions, forceReinstall);
         console.log('Added devtool extensions:', names);
         app.quit();
@@ -66,6 +70,10 @@ const removeDevtools = () => {
 };
 
 module.exports = () => {
+    if (devToolsInstaller == null) {
+        return
+    }
+
     if (process.argv.includes('--install-devtools')) {
         installDevtools();
     }


### PR DESCRIPTION
This fixes [NCP-2844](https://projecttools.nordicsemi.no/jira/browse/NCP-2844), a bug which was introduced in bada7bfc by always depending on
electron-devtools-installer, even though it is only provided when
installing the dev dependencies, so it breaks in production.

So instead we now wrap a try-catch around the `require` and provide the
functionality to install and remove devtools only if that dependency
can be resolved.

Actually, we could always provide the functionality to _remove_ the
devtools, but that would be a strange imbalance.

This PR does not add an entry to the changelog, because we had no 
release with this error.